### PR TITLE
docs: sync README and tutorials with installer and new commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,10 +138,11 @@ guardrails:
 ## System Structure
 
 ```
-IA team/
+understudy/
 ├── wizard.sh                    # 🧙 The wizard — deploys Understudy
-├── README.md                    # 📖 This file
-├── understudy.yaml            # ⚙️ Global configuration
+├── install.sh                   # 📦 One-liner curl installer
+├── run_tests.sh                 # 🧪 Local test runner
+├── understudy.yaml              # ⚙️ Global configuration
 ├── templates/                   # 📋 Base templates
 │   ├── AGENTS.md                # Copilot: team definition
 │   ├── CLAUDE.md                # Claude: global instructions
@@ -188,7 +189,13 @@ IA team/
 │   ├── ml-engineer.instructions.md
 │   ├── tech-writer.instructions.md
 │   └── sre.instructions.md
-└── docs/                        # 📚 Documentation (see "Documentation" section)
+├── tests/                       # 🧪 bats test suite
+│   ├── unit/                    # config_read, detect, deploy_file, guardrails
+│   ├── hooks/                   # guardrails-check.sh tests
+│   ├── integration/             # end-to-end wizard deployment
+│   ├── fixtures/                # fake project structures
+│   └── lib/helpers.bash         # shared test helpers
+└── docs/                        # 📚 Documentation
     ├── README.md                    # Index
     ├── 01-introduction.md
     ├── 02-quick-start.md
@@ -225,10 +232,12 @@ published as a static site without restructuring.
 
 | Command | Description |
 |---|---|
-| `./wizard.sh` | Full interactive deployment |
-| `./wizard.sh --add-member` | Add a team member (data engineer, QA, etc.) |
-| `./wizard.sh --create-role` | Create a custom role from scratch |
-| `./wizard.sh --help` | Show help |
+| `understudy` | Full interactive deployment |
+| `understudy --add-member` | Add a team member (data engineer, QA, etc.) |
+| `understudy --create-role` | Create a custom role from scratch |
+| `understudy --help` | Show help |
+
+> If you installed manually via `git clone`, replace `understudy` with `./wizard.sh`.
 
 ## Integration into Existing Projects and Monorepos
 
@@ -324,8 +333,8 @@ The `roles/` folder is the **official optional roles catalog** for the system. T
 
 **How to add them:**
 
-1. **From the existing catalog**: `./wizard.sh --add-member` → choose from menu
-2. **Create a new one**: `./wizard.sh --create-role` → saved in `roles/` for reuse
+1. **From the existing catalog**: `understudy --add-member` → choose from menu
+2. **Create a new one**: `understudy --create-role` → saved in `roles/` for reuse
 3. **Manual**: create a file `name.instructions.md` in `roles/` following the existing format
 
 > Roles you create with `--create-role` are stored in `roles/` and will be available for **all your future Understudy deployments**, not just the current project.

--- a/docs/02-quick-start.md
+++ b/docs/02-quick-start.md
@@ -2,21 +2,35 @@
 
 Works the same way on Linux, macOS and Windows (Git Bash or WSL).
 
+## Install
+
+**One-liner (recommended):**
+
 ```bash
-# 1. Clone Understudy
+curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash
+```
+
+Then open a new terminal so the `understudy` command is available.
+
+**Manual (git clone):**
+
+```bash
 git clone https://github.com/erniker/understudy.git
 cd understudy
-
-# 2. Make the wizard executable
 chmod +x wizard.sh
+# use ./wizard.sh instead of understudy in the commands below
+```
 
-# 3. Run the wizard from the folder where you want your project
-./wizard.sh
+## Deploy in a project
+
+```bash
+# Run from anywhere — the wizard asks where to deploy
+understudy
 #  → Asks project name, stack, PM, platforms (Copilot / Claude / Cursor),
 #    guardrails mode (split/embedded) and optional team members.
 #  → Detects existing projects and offers integration mode.
 
-# 4. Open the tool you use in that project
+# Then open your AI tool in the generated project
 copilot           # GitHub Copilot CLI
 # or open VS Code with Copilot enabled
 claude            # Claude Code
@@ -55,12 +69,22 @@ cursor .          # Cursor
 ## Extending the team
 
 ```bash
-./wizard.sh --add-member       # pick from roles/ (data, ML, mobile, SRE, tech-writer)
-./wizard.sh --create-role      # interactive wizard to design a new role
+understudy --add-member       # pick from roles/ (data, ML, mobile, SRE, tech-writer)
+understudy --create-role      # interactive wizard to design a new role
 ```
 
 Roles created with `--create-role` are stored in `roles/` and will be
 available in every future deployment.
+
+## Update Understudy
+
+```bash
+# Re-run the installer to get the latest version
+curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash
+
+# Or pin to a specific version
+curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash -s -- --version v1.2.0
+```
 
 ---
 

--- a/docs/09-configuration.md
+++ b/docs/09-configuration.md
@@ -25,11 +25,11 @@ platforms:
 
 models:
   architect: "claude-opus-4.6"
-  backend:   "claude-sonnet-4.6"
-  frontend:  "claude-sonnet-4.6"
-  devops:    "claude-haiku-4"
-  security:  "claude-opus-4.6"
-  qa:        "claude-sonnet-4.6"
+  backend:   "claude-sonnet-4.5"
+  frontend:  "claude-sonnet-4.5"
+  devops:    "claude-haiku-4.5"
+  security:  "claude-sonnet-4.5"
+  qa:        "claude-sonnet-4.5"
 
 guardrails:
   mode: "split"            # "split" keeps full file; "embedded" inlines critical rules

--- a/docs/10-troubleshooting.md
+++ b/docs/10-troubleshooting.md
@@ -23,11 +23,31 @@ You can answer `false` (or deselect) the platforms you don't use.
 ## How do I add a new role?
 
 ```bash
-./wizard.sh --add-member       # pick from roles/
-./wizard.sh --create-role      # create your own; saved to roles/
+understudy --add-member       # pick from roles/
+understudy --create-role      # create your own; saved to roles/
 ```
 
 Roles you create are available in every future deployment.
+
+## How do I update Understudy?
+
+Re-run the installer — it replaces `~/.understudy/` with the latest release:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash
+```
+
+To pin a specific version:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash -s -- --version v1.2.0
+```
+
+To uninstall:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash -s -- --uninstall
+```
 
 ## Existing project — will the wizard overwrite my code?
 


### PR DESCRIPTION
## Summary

Documentation gaps found after adding `install.sh` and the release pipeline — all four files were still referencing the old manual-clone workflow and `./wizard.sh` commands.

- **README.md**: fix System Structure root folder name (`IA team` → `understudy`); add `install.sh`, `run_tests.sh`, `tests/` to the tree; update Wizard Commands and role instructions to use the `understudy` command.
- **docs/02-quick-start.md**: one-liner `curl | bash` as primary install method, `git clone` as alternative; use `understudy` throughout; add Update section.
- **docs/09-configuration.md**: fix model names in the YAML example (`claude-haiku-4` → `claude-haiku-4.5`, `claude-sonnet-4.6` → `claude-sonnet-4.5`) to match `understudy.yaml` defaults.
- **docs/10-troubleshooting.md**: use `understudy` command; add FAQ entry for updating and uninstalling.

## Test plan

- [x] All links and command references verified manually
- [x] Model names match `understudy.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)