### PR TITLE
fix: enforce PR template and macOS bash compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,50 @@ on:
     branches: [main]
 
 jobs:
+  pr-template:
+    name: Pull request template
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR body
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${PR_BODY//[[:space:]]/}" ]; then
+            echo "PR body is empty. Use the pull request template."
+            exit 1
+          fi
+
+          required_sections=(
+            '## Description'
+            '## Type of change'
+            '## What changes?'
+            '## How to test'
+            '## Checklist'
+          )
+
+          for section in "${required_sections[@]}"; do
+            if ! printf '%s\n' "$PR_BODY" | grep -Fq "$section"; then
+              echo "Missing required PR template section: $section"
+              exit 1
+            fi
+          done
+
+          type_section=$(printf '%s\n' "$PR_BODY" | awk '
+            /^## Type of change$/ { capture=1; next }
+            /^---$/ && capture { exit }
+            capture { print }
+          ')
+
+          if ! printf '%s\n' "$type_section" | grep -Eq '^- \[(x|X)\] '; then
+            echo "Select at least one item in the 'Type of change' section."
+            exit 1
+          fi
+
+          echo "PR template validation passed."
+
   shellcheck:
     name: ShellCheck (bash scripts)
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -115,6 +115,20 @@ Guardrails protect the team from:
 | 🔀 **split** (recommended) | Critical guardrails always active in `copilot-instructions.md` + full details file in `guardrails.instructions.md` |
 | 📦 **embedded** | Only critical guardrails embedded in `copilot-instructions.md` (lighter, no separate file) |
 
+### Split vs Embedded: practical differences
+
+| Aspect | 🔀 split | 📦 embedded |
+|---|---|---|
+| **Enforcement level** | Critical guardrails are always active **and** full guardrails are available in a dedicated file | Only critical guardrails are always active |
+| **Visibility** | Higher: team can review complete guardrails in `guardrails.instructions.md` | Lower: only the reduced set is visible in global instructions |
+| **Maintenance** | Easier to evolve full guardrails without bloating global instructions | Simpler file structure, but less room for detailed policies |
+| **Best for** | Regulated teams, larger repos, multi-agent workflows, stricter governance | Small/fast projects, lightweight setups, teams that want minimal overhead |
+| **Trade-off** | More files and a bit more structure | Less explicit coverage of non-critical rules |
+
+**Rule of thumb:**
+- Choose **split** when you want stronger governance, better auditability and clearer team alignment.
+- Choose **embedded** when speed and simplicity matter more than policy depth.
+
 The mode is selected during the wizard and can be changed by editing `understudy.yaml`:
 
 ```yaml

--- a/wizard.sh
+++ b/wizard.sh
@@ -182,6 +182,10 @@ warn()    { echo -e "  ${YELLOW}⚠${NC}  $1"; }
 error()   { echo -e "  ${RED}✖${NC}  $1"; }
 step()    { echo -e "\n  ${CYAN}${BOLD}▸ $1${NC}"; }
 
+to_lower() {
+    printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
 ask() {
     local prompt="$1"
     local var_name="$2"
@@ -206,7 +210,7 @@ confirm() {
     local prompt="$1"
     echo -ne "  ${YELLOW}?${NC}  ${prompt} ${CYAN}[Y/n]${NC}: "
     read -r answer
-    [[ "${answer,,}" != "n" ]]
+    [[ "$(to_lower "$answer")" != "n" ]]
 }
 
 # ─── Validations ────────────────────────────────────────────
@@ -613,19 +617,19 @@ gather_project_info() {
 
     local ans_copilot ans_claude ans_cursor
     ask "Deploy for GitHub Copilot? [Y/n]" ans_copilot "Y"
-    case "${ans_copilot,,}" in
+    case "$(to_lower "$ans_copilot")" in
         n|no) PLATFORM_COPILOT=false ;;
         *) PLATFORM_COPILOT=true ;;
     esac
 
     ask "Deploy for Claude Code? [Y/n]" ans_claude "Y"
-    case "${ans_claude,,}" in
+    case "$(to_lower "$ans_claude")" in
         n|no) PLATFORM_CLAUDE=false ;;
         *) PLATFORM_CLAUDE=true ;;
     esac
 
     ask "Deploy for Cursor? [Y/n]" ans_cursor "Y"
-    case "${ans_cursor,,}" in
+    case "$(to_lower "$ans_cursor")" in
         n|no) PLATFORM_CURSOR=false ;;
         *) PLATFORM_CURSOR=true ;;
     esac


### PR DESCRIPTION
## Description

Improves the Guardrails documentation in README and adds two follow-up fixes discovered during review.
The PR now also enforces the pull request template in CI and fixes wizard prompt handling so the integration tests work with macOS default Bash.

Closes #

---

## Type of change

- [x] 🐛 `fix` — bug fix
- [ ] ✨ `feat` — new functionality
- [x] 📝 `docs` — documentation only
- [ ] ♻️ `refactor` — refactoring without behavior change
- [ ] 🧪 `test` — add or fix tests
- [x] ⚙️ `ci` — CI/CD changes
- [ ] 🔧 `chore` — maintenance
- [ ] 💥 Breaking change (breaks compatibility with previous versions)

---

## What changes?

- Clarify the practical differences between `split` and `embedded` Guardrails deployment modes in README
- Add a CI check that fails PRs missing the required template sections or a selected change type
- Replace Bash 4-only lowercase expansion in wizard prompts with a Bash 3.2-compatible helper for macOS

---

## How to test

```bash
# Documentation
# 1) Open README.md
# 2) Navigate to: Guardrails > Deployment modes
# 3) Confirm the new comparison table and rule-of-thumb are present

# CI
# 4) Open a PR without the required sections or without a checked change type
# 5) Confirm the "Pull request template" job fails

# Wizard compatibility
# 6) Run the integration tests on macOS or in GitHub Actions
# 7) Confirm the bats macOS job completes past the platform prompts
```

---

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] `CHANGELOG.md` updated in the `[Unreleased]` section
- [ ] `bash -n wizard.sh` passes without errors
- [ ] ShellCheck passes locally (or new warnings are justified)
- [x] Affected documentation is updated
- [ ] If it's a new role: follows the structure of `roles/data-engineer.instructions.md`
