### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [0.2.1] - 2026-04-27
+
+### Fixed
+
+- `wizard.sh`: replaced Bash 4-only lowercase expansion (`${var,,}`) in
+  interactive confirmations/platform prompts with a Bash 3.2-compatible
+  conversion helper, fixing integration flow on macOS runners.
+
+### Changed
+
+- `.github/workflows/ci.yml`: added a required PR body validation job that
+  enforces core sections from `.github/PULL_REQUEST_TEMPLATE.md` and requires
+  at least one selected item in `Type of change`.
+- `README.md`: expanded documentation for Guardrails deployment modes with a
+  practical `split` vs `embedded` comparison and selection rule-of-thumb.
+
 ## [0.2.0] - 2026-04-25
 
 ### Added


### PR DESCRIPTION
## Description

Release bookkeeping PR to merge the v0.2.1 changelog entry into main after tagging.

Closes #

---

## Type of change

- [ ] 🐛 fix — bug fix
- [ ] ✨ feat — new functionality
- [ ] 📝 docs — documentation only
- [ ] ♻️ refactor — refactoring without behavior change
- [ ] 🧪 test — add or fix tests
- [ ] ⚙️ ci — CI/CD changes
- [x] 🔧 chore — maintenance
- [ ] 💥 Breaking change (breaks compatibility with previous versions)

---

## What changes?

- Add [0.2.1] section to CHANGELOG.md
- Include notes for macOS bash compatibility fix, PR template CI enforcement, and guardrails docs clarification
- Keep Unreleased section at the top

---

## How to test

```bash
# 1) Open CHANGELOG.md
# 2) Confirm [Unreleased] exists at top
# 3) Confirm [0.2.1] - 2026-04-27 section includes Fixed/Changed entries
```

---

## Checklist

- [x] Commits follow Conventional Commits
- [x] CHANGELOG.md updated in the [Unreleased] section
- [ ] bash -n wizard.sh passes without errors
- [ ] ShellCheck passes locally (or new warnings are justified)
- [x] Affected documentation is updated
- [ ] If it's a new role: follows the structure of roles/data-engineer.instructions.md
