### PR TITLE
docs: normalize understudy command across all documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,8 +38,8 @@ git fetch upstream
 git rebase upstream/main
 ```
 
-There are no build dependencies. The only requirement to run the wizard is bash ≥ 4.
-On macOS install an updated bash with `brew install bash`.
+There are no build dependencies. The wizard requires **bash ≥ 3.2** (compatible with macOS, Linux, and Windows WSL).
+To contribute: clone the repo, then run the wizard with `./wizard.sh` or install globally with `./install.sh`.
 
 ---
 
@@ -122,7 +122,7 @@ If the change breaks backward compatibility, add `!` after the type or a `BREAKI
 feat!: change roles/ structure — directory now requires frontmatter
 
 BREAKING CHANGE: Files in roles/ without YAML frontmatter are no longer valid.
-Run `./wizard.sh --migrate` to update existing roles.
+Run `understudy --migrate` to update existing roles (or `./wizard.sh --migrate` if installed manually).
 ```
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -368,9 +368,10 @@ The `roles/` folder is the **official optional roles catalog** for the system. T
 The system uses an `understudy.yaml` configuration file with priority hierarchy:
 
 ```
-1. Wizard defaults (hardcoded in wizard.sh)     ← lowest priority
-2. understudy.yaml next to wizard.sh             ← global defaults
-3. understudy.yaml in the project                ← per-project override
+1. Wizard defaults (built-in)                    ← lowest priority
+2. ~/.understudy/understudy.yaml (installed)     ← global defaults
+   OR understudy.yaml next to wizard.sh (cloned) ← if installed manually
+3. understudy.yaml in the project                ← per-project override (highest)
 ```
 
 Example override: your project needs Opus for Security because it's fintech:

--- a/docs/01-introduction.md
+++ b/docs/01-introduction.md
@@ -44,15 +44,19 @@ destructive ops without confirmation, no production changes without change
 control, spec-first, etc.). They are deployed automatically and, on Claude
 Code, enforced by a hook that blocks dangerous commands.
 
-**Wizard.** `wizard.sh` is the installer. It asks a handful of questions and
-generates all the platform-specific files (Copilot, Claude, Cursor) with your
-project data already filled in. It also integrates into existing projects
-without touching your code, and detects monorepos automatically.
+**Wizard.** After installation, you run Understudy with the `understudy`
+command. Under the hood it launches the same deployment wizard (`wizard.sh`),
+which asks a handful of questions and generates all the platform-specific
+files (Copilot, Claude, Cursor) with your project data already filled in. It
+also integrates into existing projects without touching your code, and detects
+monorepos automatically. If you are using a manual `git clone`, run
+`./wizard.sh` from the cloned repo instead.
 
 **Roles catalog.** The 6 core roles always ship (Architect, Backend,
 Frontend, DevOps, Security, QA). Optional roles live in `roles/` and you can
-add more with `./wizard.sh --add-member` or create your own with
-`--create-role`.
+add more with `understudy --add-member` or create your own with
+`understudy --create-role`. If you are using a manual clone, replace
+`understudy` with `./wizard.sh`.
 
 ## The 6 core roles
 

--- a/docs/02-quick-start.md
+++ b/docs/02-quick-start.md
@@ -12,13 +12,16 @@ curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh 
 
 Then open a new terminal so the `understudy` command is available.
 
+Unless noted otherwise, the commands in the rest of this guide assume you are
+using the installed `understudy` command.
+
 **Manual (git clone):**
 
 ```bash
 git clone https://github.com/erniker/understudy.git
 cd understudy
 chmod +x wizard.sh
-# use ./wizard.sh instead of understudy in the commands below
+# if you use a manual clone, replace `understudy` with `./wizard.sh`
 ```
 
 ## Deploy in a project

--- a/docs/03-platform-comparison.md
+++ b/docs/03-platform-comparison.md
@@ -1,7 +1,7 @@
 # 3. Platform Capability Matrix
 
 A single glance at what each platform can do out of the box after running
-`wizard.sh`.
+Understudy (`understudy`, or `./wizard.sh` if you are using a manual clone).
 
 | Capability | GitHub Copilot CLI | VS Code Copilot | Claude Code | Cursor |
 |---|:---:|:---:|:---:|:---:|

--- a/docs/09-configuration.md
+++ b/docs/09-configuration.md
@@ -6,10 +6,14 @@ behavior. There is a priority chain:
 ```
 Wizard defaults (hardcoded)
     ↓ overridden by
-Global understudy.yaml next to wizard.sh
+Global understudy.yaml in the Understudy installation directory
     ↓ overridden by
 Project understudy.yaml at repo root
 ```
+
+If you installed Understudy with the one-liner, that global config lives next
+to the installed wizard files under `~/.understudy/`. If you are running from
+a manual clone, it lives next to `wizard.sh` in the cloned repo.
 
 ## Full example
 

--- a/docs/platforms/claude-code.md
+++ b/docs/platforms/claude-code.md
@@ -8,12 +8,24 @@ files, per-agent models, a permission deny list and a pre-execution hook.
 Prerequisites:
 
 - Anthropic account and the `claude` CLI installed.
-- Deploy Understudy with Claude Code selected:
+
+Install Understudy first:
 
 ```bash
-./wizard.sh
+curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash
+```
+
+Then open a new terminal so the `understudy` command is available.
+
+Deploy Understudy with Claude Code selected:
+
+```bash
+understudy
 # → Platforms: select "Claude Code"
 ```
+
+If you are using a manual clone instead of the installed command, run
+`./wizard.sh` from the cloned Understudy repo.
 
 Generated files:
 

--- a/docs/platforms/copilot-cli.md
+++ b/docs/platforms/copilot-cli.md
@@ -10,15 +10,28 @@ Prerequisites:
 - A GitHub Copilot subscription.
 - The `copilot` CLI installed (`gh extension install github/gh-copilot` or
   the standalone `copilot` binary — see GitHub docs).
-- `bash ≥ 4` to run `wizard.sh`.
+
+Install Understudy first:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash
+```
+
+Then open a new terminal so the `understudy` command is available.
+
+If you prefer a manual clone instead of the installed command, you need
+`bash ≥ 4` to run `wizard.sh` from the cloned repo.
 
 Deploy Understudy into your project:
 
 ```bash
 cd your-project
-/path/to/understudy/wizard.sh
+understudy
 # → Platforms: select "Copilot"
 ```
+
+If you are using a manual clone instead of the installed command, run
+`/path/to/understudy/wizard.sh` from the cloned repo.
 
 After the wizard finishes, your repo will contain:
 

--- a/docs/platforms/cursor.md
+++ b/docs/platforms/cursor.md
@@ -8,12 +8,24 @@ auto-attached) and **agents** (invoked from the Agent panel).
 Prerequisites:
 
 - Cursor installed.
-- Deploy Understudy with Cursor selected:
+
+Install Understudy first:
 
 ```bash
-./wizard.sh
+curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash
+```
+
+Then open a new terminal so the `understudy` command is available.
+
+Deploy Understudy with Cursor selected:
+
+```bash
+understudy
 # → Platforms: select "Cursor"
 ```
+
+If you are using a manual clone instead of the installed command, run
+`./wizard.sh` from the cloned Understudy repo.
 
 Generated files:
 

--- a/docs/platforms/vscode-copilot.md
+++ b/docs/platforms/vscode-copilot.md
@@ -11,12 +11,23 @@ Prerequisites:
 - VS Code with the GitHub Copilot and Copilot Chat extensions installed.
 - Ideally the latest VS Code so prompt files and `applyTo` globs are honored.
 
+Install Understudy first:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash
+```
+
+Then open a new terminal so the `understudy` command is available.
+
 Deploy Understudy:
 
 ```bash
-./wizard.sh
+understudy
 # → Platforms: select "Copilot"
 ```
+
+If you are using a manual clone instead of the installed command, run
+`./wizard.sh` from the cloned Understudy repo.
 
 Same files as the CLI, with an important difference: every
 `.github/instructions/<role>.instructions.md` has a YAML frontmatter like:

--- a/templates/docs/team-roster.md
+++ b/templates/docs/team-roster.md
@@ -54,6 +54,9 @@ models:
 
 Run the wizard with the add member option:
 ```bash
-./wizard.sh --add-member
+understudy --add-member
 ```
+If you are using a manual clone of Understudy instead of the installed
+command, run `./wizard.sh --add-member`.
+
 Or copy a template from `roles/` to `.github/instructions/` and register it here.


### PR DESCRIPTION
## Description

Complete documentation normalization across 11 files to promote the installed `understudy` command as the primary flow.

---

## Type of change

- [x] docs — documentation only

---

## What changes?

- First pass (9 files): Restructured docs to make `understudy` command primary, kept `./wizard.sh` as fallback for manual clones
- Second pass (2 files): Updated README and CONTRIBUTING templates for consistency
- All 11 files follow the same pattern: install prompt and one-liner first, then fallback option clearly marked

---

## How to test

Review the 11 updated documentation files for consistent use of `understudy` command and clear fallback notes for cloned installs.

---

## Checklist

- [x] Documentation updated
