### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-27
+
 ### Added
 
 - **Local-only mode**: two new wizard questions and `git.local_config` /


### PR DESCRIPTION
## Description

Prepares the v0.3.0 release: renames `[Unreleased]` to `[0.3.0] - 2026-04-27` in CHANGELOG.md.

---

## Type of change

- [x] Documentation update

---

## What changes?

- `CHANGELOG.md`: rename `[Unreleased]` → `[0.3.0] - 2026-04-27`

---

## How to test

- [x] CHANGELOG format follows Keep a Changelog spec

---

## Checklist

- [x] Branch in sync with `main`
- [x] `CHANGELOG.md` updated
- [x] Commits follow Conventional Commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)