### PR TITLE
docs: surface local-only mode in README and quick-start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Changed
+
+- `README.md`: added "Local-only mode" key concept so the v0.3.0 feature is
+  visible from the project entry page.
+- `docs/01-introduction.md`: noted that the wizard can append paths to
+  `.gitignore` when local-only mode is enabled.
+- `docs/02-quick-start.md`: updated the wizard question summary to include
+  the local-only mode prompts.
+- `docs/README.md`: linked the new "Local-only mode" subsection from the
+  configuration entry in the docs index.
+
 ## [0.3.0] - 2026-04-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ They cover 8 categories: security, scope, process, destructive operations,
 data/PII, quality, environments and documentation. They are **non-negotiable** and
 deployed automatically with the wizard.
 
+### 7. 🔒 Local-only mode — "Keep AI config out of git"
+Optional. The wizard can append the generated AI config (`AGENTS.md`,
+`CLAUDE.md`, `.github/instructions/`, `.claude/`, `.cursor/`…) and/or the
+session memory files (`docs/spec.md`, `docs/decisions.md`,
+`docs/session-log.md`) to the project's `.gitignore` so they stay local.
+Useful in corporate repos where AI tool config is private, or open source
+projects where you don't want to expose your internal workflow. Toggle with
+`git.local_config` / `git.local_memory` in `understudy.yaml` — see
+[docs/09-configuration.md](docs/09-configuration.md#local-only-mode).
+
 ## Guardrails
 
 Guardrails protect the team from:

--- a/docs/01-introduction.md
+++ b/docs/01-introduction.md
@@ -105,6 +105,11 @@ your-project/
     └── rules/                    # Global rules + guardrails (always-on)
 ```
 
+If you enable **local-only mode** during the wizard, Understudy also appends
+the affected paths to the project's `.gitignore` so AI config and/or session
+memory stay out of git. See
+[Configuration → Local-only mode](09-configuration.md#local-only-mode).
+
 ---
 
 Next: [Quick Start](02-quick-start.md)

--- a/docs/02-quick-start.md
+++ b/docs/02-quick-start.md
@@ -30,7 +30,8 @@ chmod +x wizard.sh
 # Run from anywhere — the wizard asks where to deploy
 understudy
 #  → Asks project name, stack, PM, platforms (Copilot / Claude / Cursor),
-#    guardrails mode (split/embedded) and optional team members.
+#    guardrails mode (split/embedded), local-only mode (keep AI config and/or
+#    session memory out of git) and optional team members.
 #  → Detects existing projects and offers integration mode.
 
 # Then open your AI tool in the generated project
@@ -47,6 +48,8 @@ cursor .          # Cursor
   `docs/team-roster.md` were scaffolded.
 - Guardrails were deployed according to `understudy.yaml → guardrails.mode`
   (`split` keeps them in a dedicated file, `embedded` inlines critical rules).
+- If you opted into local-only mode, the affected paths were appended to the
+  project's `.gitignore` (see [Configuration → Local-only mode](09-configuration.md#local-only-mode)).
 - Nothing else in your repository was modified.
 
 ## First session, step by step

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ restructuring.
    - [Cursor](platforms/cursor.md)
 5. [Cross-Platform Workflows](08-cross-platform-workflows.md)
 6. [Configuration Reference (`understudy.yaml`)](09-configuration.md)
+   - [Local-only mode](09-configuration.md#local-only-mode) — keep AI config out of git
 7. [Troubleshooting and FAQ](10-troubleshooting.md)
 
 ## How to read this


### PR DESCRIPTION
## Description

v0.3.0 added the local-only mode (`git.local_config` / `git.local_memory`),
but the user-facing entry points still listed only the pre-0.3.0 wizard
questions and made no mention of the feature. A new user landing on the
README or following the quick start would not discover it. This PR surfaces
the feature in the four places a reader is most likely to look first.

No code or behavior changes — docs only.

---

## Type of change

- [x] 📝 `docs` — documentation only

---

## What changes?

- `README.md`: new key concept **7. 🔒 Local-only mode** under "Key Concepts",
  linking to the configuration reference.
- `docs/02-quick-start.md`: updated the wizard question summary to include
  the local-only prompts; added a bullet in "What just happened" about the
  `.gitignore` append.
- `docs/01-introduction.md`: noted that the wizard can append paths to
  `.gitignore` when local-only mode is enabled.
- `docs/README.md`: sub-link from the Configuration entry directly to the
  "Local-only mode" subsection.
- `CHANGELOG.md`: entries under `[Unreleased] → Changed`.

---

## How to test

```bash
# Read the four touched pages and verify the new wording is consistent
# and the anchor link resolves:
#   docs/09-configuration.md#local-only-mode
```

- [x] All cross-links point to existing files / anchors
- [x] No code changes — wizard behavior unchanged

---

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] `CHANGELOG.md` updated in the `[Unreleased]` section
- [x] `bash -n wizard.sh` passes without errors (no shell changes)
- [x] ShellCheck passes locally (no shell changes)
- [x] Affected documentation is updated
- [x] If it's a new role: N/A
