### PR TITLE
feat(wizard): automatic update check on every invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-28
+
+### Added
+
+- **Automatic update check**: `wizard.sh` now queries the GitHub Releases API at
+  startup. If a newer version is available it asks the user whether to update
+  immediately (runs the installer one-liner and re-executes the wizard).
+  Skipped automatically in non-interactive runs (stdin not a tty) and in
+  development clones (`.git` present next to `wizard.sh`). Can be suppressed
+  with `export UNDERSTUDY_SKIP_UPDATE_CHECK=1`.
+- `tests/unit/update_check.bats`: 8 unit tests for `read_local_version` and
+  `version_is_newer` (major / minor / patch / equal / lower / prerelease).
+
 ### Changed
 
 - `README.md`: added "Local-only mode" key concept so the v0.3.0 feature is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -371,7 +371,10 @@ tests/
 │   ├── detect_existing_project.bats      # Stack detection: Node/React/Vue/Angular,
 │   │                                     # .NET, Python, Terraform, Docker, Monorepo
 │   ├── deploy_file.bats                  # Placeholder substitution + file preservation
-│   └── inject_guardrails.bats            # Guardrail injection: split vs embedded modes
+│   ├── deploy_gitignore.bats             # Local-only mode: .gitignore generation per platform
+│   ├── inject_guardrails.bats            # Guardrail injection: split vs embedded modes
+│   ├── normalize_path.bats               # Windows/Unix path normalization (Git Bash, WSL)
+│   └── update_check.bats                 # Version comparison + local version detection
 ├── hooks/
 │   └── guardrails_check.bats             # Hook blocks destructive commands (exit 2),
 │                                         # warns on secrets (exit 0), allows safe ops
@@ -418,6 +421,9 @@ Key conventions:
 | New destructive pattern in `guardrails-check.sh` | `tests/hooks/guardrails_check.bats` |
 | New platform, new files deployed, new wizard flag | `tests/integration/deploy_all_platforms.bats` |
 | New fixture needed for detection | `tests/fixtures/` |
+| Update checker (`read_local_version`, `version_is_newer`) | `tests/unit/update_check.bats` |
+| Path normalization (`normalize_path`) | `tests/unit/normalize_path.bats` |
+| Git integration / `.gitignore` generation | `tests/unit/deploy_gitignore.bats` |
 
 ### Writing tests for a new feature — checklist
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ cursor .          # Cursor
 | `--no-path` | Skip PATH setup |
 | `--uninstall` | Remove Understudy from the system |
 
+### Automatic update checks
+
+When you run `understudy`, it checks for a new release on GitHub.
+If a newer version exists, it asks whether you want to update now.
+
+To disable this check (for CI or offline environments):
+
+```bash
+export UNDERSTUDY_SKIP_UPDATE_CHECK=1
+```
+
 ## What is this?
 
 A system that automatically generates all the configuration needed for

--- a/docs/02-quick-start.md
+++ b/docs/02-quick-start.md
@@ -84,12 +84,18 @@ available in every future deployment.
 
 ## Update Understudy
 
+Every time you invoke `understudy`, it checks if a newer release exists and can
+prompt you to update immediately.
+
 ```bash
 # Re-run the installer to get the latest version
 curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash
 
 # Or pin to a specific version
 curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash -s -- --version v1.2.0
+
+# Disable auto-check (useful for CI/offline)
+export UNDERSTUDY_SKIP_UPDATE_CHECK=1
 ```
 
 ---

--- a/docs/10-troubleshooting.md
+++ b/docs/10-troubleshooting.md
@@ -49,7 +49,10 @@ Roles you create are available in every future deployment.
 
 ## How do I update Understudy?
 
-Re-run the installer — it replaces `~/.understudy/` with the latest release:
+Every time you run `understudy`, it checks GitHub for a newer release and
+prompts you to update automatically. Just answer **Y** when asked.
+
+If you prefer to update manually, re-run the installer:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash
@@ -59,6 +62,12 @@ To pin a specific version:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash -s -- --version v1.2.0
+```
+
+To disable the automatic check (CI, offline environments):
+
+```bash
+export UNDERSTUDY_SKIP_UPDATE_CHECK=1
 ```
 
 To uninstall:

--- a/tests/unit/update_check.bats
+++ b/tests/unit/update_check.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+# Tests for update-check helper functions in wizard.sh.
+
+load "../lib/helpers"
+
+setup() {
+  source_wizard_functions
+  setup_tmp
+}
+
+teardown() {
+  teardown_tmp
+}
+
+@test "read_local_version reads first released version from changelog" {
+  cat > "${TEST_TMP}/CHANGELOG.md" << 'EOF'
+# Changelog
+
+## [0.4.1] - 2026-05-01
+### Added
+- Something
+
+## [0.4.0] - 2026-04-30
+### Fixed
+- Something else
+EOF
+
+  run read_local_version "${TEST_TMP}/CHANGELOG.md"
+  [ "$status" -eq 0 ]
+  [ "$output" = "v0.4.1" ]
+}
+
+@test "read_local_version fails if changelog is missing" {
+  run read_local_version "${TEST_TMP}/missing.md"
+  [ "$status" -eq 1 ]
+}
+
+@test "version_is_newer returns true when latest major is higher" {
+  run version_is_newer "v1.0.0" "v0.9.9"
+  [ "$status" -eq 0 ]
+}
+
+@test "version_is_newer returns true when latest minor is higher" {
+  run version_is_newer "v0.4.0" "v0.3.9"
+  [ "$status" -eq 0 ]
+}
+
+@test "version_is_newer returns true when latest patch is higher" {
+  run version_is_newer "v0.3.1" "v0.3.0"
+  [ "$status" -eq 0 ]
+}
+
+@test "version_is_newer returns false when versions are equal" {
+  run version_is_newer "v0.3.0" "v0.3.0"
+  [ "$status" -eq 1 ]
+}
+
+@test "version_is_newer returns false when latest is lower" {
+  run version_is_newer "v0.2.9" "v0.3.0"
+  [ "$status" -eq 1 ]
+}
+
+@test "version_is_newer ignores prerelease suffix" {
+  run version_is_newer "v0.4.0-rc1" "v0.3.9"
+  [ "$status" -eq 0 ]
+}

--- a/wizard.sh
+++ b/wizard.sh
@@ -287,7 +287,7 @@ check_for_updates() {
     [[ -d "${SCRIPT_DIR}/.git" ]] && return 0
 
     local current_version latest_version
-    current_version="$(read_local_version 2>/dev/null || true)"
+    current_version="$(read_local_version "${SCRIPT_DIR}/CHANGELOG.md" 2>/dev/null || true)"
     [[ -n "$current_version" ]] || return 0
 
     latest_version="$(fetch_latest_version 2>/dev/null || true)"

--- a/wizard.sh
+++ b/wizard.sh
@@ -28,6 +28,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TEMPLATES_DIR="${SCRIPT_DIR}/templates"
 ROLES_DIR="${SCRIPT_DIR}/roles"
 DEFAULT_CONFIG="${SCRIPT_DIR}/understudy.yaml"
+UPDATE_REPO="erniker/understudy"
+UPDATE_API_URL="https://api.github.com/repos/${UPDATE_REPO}/releases/latest"
+UPDATE_INSTALL_URL="https://raw.githubusercontent.com/${UPDATE_REPO}/main/install.sh"
 
 # ─── Config defaults (overridden by understudy.yaml) ───────
 MODEL_ARCHITECT="claude-opus-4.6"
@@ -229,6 +232,81 @@ confirm() {
     echo -ne "  ${YELLOW}?${NC}  ${prompt} ${CYAN}[Y/n]${NC}: "
     read -r answer
     [[ "$(to_lower "$answer")" != "n" ]]
+}
+
+# ─── Version and update check ───────────────────────────────
+
+read_local_version() {
+    local changelog_file="${1:-${SCRIPT_DIR}/CHANGELOG.md}"
+    [[ -f "$changelog_file" ]] || return 1
+
+    awk -F'[][]' '
+        /^## \[[0-9]+\.[0-9]+\.[0-9]+\]/ {
+            print "v" $2
+            exit
+        }
+    ' "$changelog_file"
+}
+
+fetch_latest_version() {
+    command -v curl &>/dev/null || return 1
+
+    curl -fsSL \
+        --connect-timeout 2 \
+        --max-time 4 \
+        "$UPDATE_API_URL" \
+        -H "Accept: application/vnd.github+json" \
+        | awk -F'"' '/"tag_name"/ { print $4; exit }'
+}
+
+version_is_newer() {
+    local latest="${1#v}"
+    local current="${2#v}"
+    latest="${latest%%-*}"
+    current="${current%%-*}"
+
+    local l1=0 l2=0 l3=0 c1=0 c2=0 c3=0
+    IFS='.' read -r l1 l2 l3 <<< "$latest"
+    IFS='.' read -r c1 c2 c3 <<< "$current"
+    l1=${l1:-0}; l2=${l2:-0}; l3=${l3:-0}
+    c1=${c1:-0}; c2=${c2:-0}; c3=${c3:-0}
+
+    if (( l1 > c1 )); then return 0; fi
+    if (( l1 < c1 )); then return 1; fi
+    if (( l2 > c2 )); then return 0; fi
+    if (( l2 < c2 )); then return 1; fi
+    if (( l3 > c3 )); then return 0; fi
+    return 1
+}
+
+check_for_updates() {
+    [[ "${UNDERSTUDY_SKIP_UPDATE_CHECK:-0}" == "1" ]] && return 0
+
+    # Skip in non-interactive runs and local development clones.
+    [[ -t 0 ]] || return 0
+    [[ -d "${SCRIPT_DIR}/.git" ]] && return 0
+
+    local current_version latest_version
+    current_version="$(read_local_version 2>/dev/null || true)"
+    [[ -n "$current_version" ]] || return 0
+
+    latest_version="$(fetch_latest_version 2>/dev/null || true)"
+    [[ -n "$latest_version" ]] || return 0
+
+    if version_is_newer "$latest_version" "$current_version"; then
+        warn "New Understudy version available: ${latest_version} (current: ${current_version})"
+        if confirm "Do you want to update now?"; then
+            step "Updating Understudy"
+            if curl -fsSL "$UPDATE_INSTALL_URL" | bash; then
+                success "Update completed. Restarting Understudy..."
+                exec "$0" "$@"
+            else
+                warn "Update failed. Continuing with current version (${current_version})."
+            fi
+        fi
+    fi
+
+    return 0
 }
 
 # ─── Validations ────────────────────────────────────────────
@@ -1368,6 +1446,8 @@ show_help() {
 # ─── Main ────────────────────────────────────────────────────
 
 main() {
+    check_for_updates "$@"
+
     case "${1:-}" in
         --help|-h)
             show_help


### PR DESCRIPTION
## Description

Adds an automatic version check at the start of every `understudy` invocation. When a newer release is available on GitHub the wizard asks `[Y/n]` to update immediately (runs the installer one-liner and re-executes).

Closes #

---

## Type of change

- [ ] 🐛 `fix` — bug fix
- [x] ✨ `feat` — new functionality
- [ ] 📝 `docs` — documentation only
- [ ] ♻️ `refactor` — refactoring without behavior change
- [x] 🧪 `test` — add or fix tests
- [ ] ⚙️ `ci` — CI/CD changes
- [ ] 🔧 `chore` — maintenance
- [ ] 💥 Breaking change (breaks compatibility with previous versions)

---

## What changes?

- `wizard.sh`: new functions `read_local_version`, `fetch_latest_version`, `version_is_newer`, `check_for_updates`; called from `main()` at startup.
- All skip-paths return `0` so the check is safe under `set -e` (non-interactive / piped runs, dev clones, no curl, API timeout).
- Opt-out: `export UNDERSTUDY_SKIP_UPDATE_CHECK=1`.
- `tests/unit/update_check.bats`: 8 new unit tests (major/minor/patch/equal/lower/prerelease, missing changelog).
- Docs: `README.md`, `docs/02-quick-start.md`, `docs/10-troubleshooting.md`, `CONTRIBUTING.md`, `CHANGELOG.md` (v0.4.0).

---

## How to test

```bash
# Unit tests (includes 8 new update_check tests)
./run_tests.sh unit

# Full suite
./run_tests.sh all
```

---

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] `CHANGELOG.md` updated in the `[Unreleased]` section
- [x] `bash -n wizard.sh` passes without errors
- [x] ShellCheck passes locally (or new warnings are justified)
- [x] Affected documentation is updated
- [ ] If it's a new role: follows the structure of `roles/data-engineer.instructions.md`
