### PR TITLE
fix(install): fix banner padding with platform-independent calculation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -215,15 +215,17 @@ setup_path() {
 
 # ── Post-install summary ──────────────────────────────────────
 post_install() {
-  local msg="🎭  Understudy ${VERSION} installed!"
-  # Emoji counts as 1 in bash but takes 2 visual spaces, so subtract 1 from padding
-  local padding=$((42 - ${#msg} - 1))
+  # Build msg separately: emoji (always 2 visual columns) + text part
+  # Inner box width = 42: "║  🎭{text}{spaces} ║" → 2 + 2 + text_len + spaces + 1 = 42
+  # spaces = 37 - text_len  (independent of how bash counts the emoji)
+  local text="  Understudy ${VERSION} installed!"
+  local padding=$((37 - ${#text}))
   local spaces=""
   for ((i = 0; i < padding; i++)); do spaces+=" "; done
-  
+
   echo ""
   echo -e "  ${GREEN}${BOLD}╔══════════════════════════════════════════╗${NC}"
-  printf "  ${GREEN}${BOLD}║  %s%s ║${NC}\n" "$msg" "$spaces"
+  printf "  ${GREEN}${BOLD}║  🎭%s%s ║${NC}\n" "$text" "$spaces"
   echo -e "  ${GREEN}${BOLD}╚══════════════════════════════════════════╝${NC}"
   echo ""
   step "Quick start"


### PR DESCRIPTION
## Description

Previous banner padding fix still produced misalignment. The root cause: bash counts emoji differently by platform:
- Linux/macOS: `🎭` = **1** character (`${#msg}` = 31)
- Git Bash on Windows: `🎭` = **2** characters (`${#msg}` = 32)

This made any calculation using `${#msg}` produce different spacing per platform.

**Fix**: Separate the emoji from the text in the padding calculation. The text length is always stable; the emoji visual width is hardcoded as 2 columns in the `printf` format string.

---

## Type of change

- [x] 🐛 `fix` — bug fix
- [ ] ✨ `feat` — new functionality
- [ ] 📝 `docs` — documentation only
- [ ] ♻️ `refactor` — refactoring without behavior change
- [ ] 🧪 `test` — add or fix tests
- [ ] ⚙️ `ci` — CI/CD changes
- [ ] 🔧 `chore` — maintenance

---

## What changes?

- Split msg into emoji + text: `printf '║  🎭%s%s ║' "$text" "$spaces"`
- Formula: `spaces = 37 - ${#text}` (independent of emoji encoding)
- Verified: text_len=30, padding=7, inner width=2+2+30+7+1=42 ✓
- Consistent output on Linux, macOS, and Git Bash on Windows

---

## How to test

```bash
bash ./install.sh --version v0.4.2 --no-path
```

Expected banner (properly aligned rectangle):
```
  ╔══════════════════════════════════════════╗
  ║  🎭  Understudy v0.4.2 installed!  ║
  ╚══════════════════════════════════════════╝
```

---

## Checklist

- [x] Commits follow Conventional Commits
- [ ] CHANGELOG.md updated in the [Unreleased] section
- [x] `bash -n install.sh` passes without errors
- [x] ShellCheck passes locally
- [ ] Affected documentation is updated
