### PR TITLE
fix(changelog): add v0.4.1-v0.4.3 entries to fix infinite update loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-04-28
+
+### Fixed
+
+- `install.sh`: fixed banner padding with platform-independent calculation.
+  Bash counts emoji width differently per platform (1 char on Linux/macOS,
+  2 chars on Git Bash/Windows). Separated emoji from text in the padding
+  formula so the result is consistent across all platforms.
+
+## [0.4.2] - 2026-04-28
+
+### Fixed
+
+- `install.sh`: improved bash shell config detection — checks `.bash_profile`
+  first (used by macOS login shells) before falling back to `.bashrc` (Linux).
+
+## [0.4.1] - 2026-04-28
+
+### Fixed
+
+- `install.sh`: first attempt at aligning release banner (partial fix).
+
 ## [0.4.0] - 2026-04-28
 
 ### Added


### PR DESCRIPTION
## Description

`read_local_version()` parses `CHANGELOG.md` to detect the installed version. Because v0.4.1, v0.4.2, and v0.4.3 were patch releases that never updated the CHANGELOG, the release tarballs always contained `## [0.4.0]` as the latest entry. This caused `check_for_updates()` to always detect a newer version (v0.4.3 > v0.4.0) and prompt the user — even right after a successful update — creating an infinite update loop.

---

## Type of change

- [x] 🐛 `fix` — bug fix
- [ ] ✨ `feat` — new functionality
- [ ] 📝 `docs` — documentation only
- [ ] ♻️ `refactor` — refactoring without behavior change
- [ ] 🧪 `test` — add or fix tests
- [ ] ⚙️ `ci` — CI/CD changes
- [ ] 🔧 `chore` — maintenance

---

## What changes?

- Added `## [0.4.3]`, `## [0.4.2]`, `## [0.4.1]` entries to `CHANGELOG.md`
- Now the release tarball includes the correct version tag and `read_local_version()` returns `v0.4.3`
- `check_for_updates()` correctly detects "already up to date" after installation

---

## How to test

```bash
curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash
# Run understudy — should NOT prompt for update if already on latest
understudy --help
```

---

## Checklist

- [x] Commits follow Conventional Commits
- [x] `CHANGELOG.md` updated in the `[Unreleased]` section
- [x] `bash -n wizard.sh` passes without errors
- [x] ShellCheck passes locally
- [x] Affected documentation is updated
