### PR TITLE
ci(release): require changelog entry before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,21 @@ jobs:
           # Strip the leading 'v' to match CHANGELOG format (e.g. v1.2.0 → 1.2.0)
           semver="${version#v}"
 
+          # Require an explicit changelog section for the tag being released
+          if ! grep -q "^## \[${semver}\]" CHANGELOG.md; then
+            echo "ERROR: Missing CHANGELOG entry for ${version}."
+            echo "Add a section like: ## [${semver}] - YYYY-MM-DD"
+            exit 1
+          fi
+
           # Extract the block between ## [X.Y.Z] and the next ## heading
           notes=$(awk "/^## \[${semver}\]/{found=1; next} found && /^## /{exit} found{print}" CHANGELOG.md)
 
-          if [[ -z "$notes" ]]; then
-            notes="See [CHANGELOG.md](CHANGELOG.md) for details."
+          # Require non-empty release notes under that section
+          if [[ -z "$(printf '%s' "$notes" | tr -d '[:space:]')" ]]; then
+            echo "ERROR: CHANGELOG section for ${version} is empty."
+            echo "Add at least one item under ## [${semver}] before tagging/releasing."
+            exit 1
           fi
 
           # Write to file to preserve newlines


### PR DESCRIPTION
## Description

Adds a release guardrail in CI so a tagged release cannot be published unless `CHANGELOG.md` has a matching and non-empty section for that version.

This prevents publishing tags with missing notes and avoids version-detection regressions caused by incomplete changelog history.

---

## Type of change

- [ ] 🐛 `fix` — bug fix
- [ ] ✨ `feat` — new functionality
- [ ] 📝 `docs` — documentation only
- [ ] ♻️ `refactor` — refactoring without behavior change
- [ ] 🧪 `test` — add or fix tests
- [x] ⚙️ `ci` — CI/CD changes
- [ ] 🔧 `chore` — maintenance
- [ ] 💥 Breaking change (breaks compatibility with previous versions)

---

## What changes?

- In `.github/workflows/release.yml`, fail the release job if `## [X.Y.Z]` is missing for the pushed tag `vX.Y.Z`
- Fail the release job if that changelog section exists but has no content
- Keep using the extracted changelog block as `release_notes.md` when valid

---

## How to test

```bash
# Case 1: missing section
# Push a tag vX.Y.Z without a matching ## [X.Y.Z] entry in CHANGELOG.md
# Expected: release workflow fails with "Missing CHANGELOG entry"

# Case 2: empty section
# Add ## [X.Y.Z] with no bullet/content and push tag
# Expected: release workflow fails with "CHANGELOG section ... is empty"

# Case 3: valid section
# Add non-empty ## [X.Y.Z] section and push tag
# Expected: release workflow succeeds and publishes release notes from CHANGELOG
```

---

## Checklist

- [x] Commits follow Conventional Commits
- [ ] `CHANGELOG.md` updated in the `[Unreleased]` section
- [x] `bash -n wizard.sh` passes without errors
- [x] ShellCheck passes locally (or new warnings are justified)
- [ ] Affected documentation is updated
