### PR TITLE
feat(roles): add git-specialist and shell-scripting roles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,21 @@ jobs:
           # Strip the leading 'v' to match CHANGELOG format (e.g. v1.2.0 → 1.2.0)
           semver="${version#v}"
 
+          # Require an explicit changelog section for the tag being released
+          if ! grep -q "^## \[${semver}\]" CHANGELOG.md; then
+            echo "ERROR: Missing CHANGELOG entry for ${version}."
+            echo "Add a section like: ## [${semver}] - YYYY-MM-DD"
+            exit 1
+          fi
+
           # Extract the block between ## [X.Y.Z] and the next ## heading
           notes=$(awk "/^## \[${semver}\]/{found=1; next} found && /^## /{exit} found{print}" CHANGELOG.md)
 
-          if [[ -z "$notes" ]]; then
-            notes="See [CHANGELOG.md](CHANGELOG.md) for details."
+          # Require non-empty release notes under that section
+          if [[ -z "$(printf '%s' "$notes" | tr -d '[:space:]')" ]]; then
+            echo "ERROR: CHANGELOG section for ${version} is empty."
+            echo "Add at least one item under ## [${semver}] before tagging/releasing."
+            exit 1
           fi
 
           # Write to file to preserve newlines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- New optional roles: **git-specialist** (Git workflows, branch policies, PR hygiene)
+  and **shell-scripting** (Bash/sh automation, cross-platform scripting, ShellCheck).
+- Auto-deploy of optional roles: `git-specialist` is always included;
+  `shell-scripting` is added automatically when `*.sh`/`*.bash`/`*.zsh` files
+  are detected in the project.
+- Shell detection in `detect_existing_project()`: scans for `*.sh`, `*.bash`,
+  `*.zsh` files and adds "Shell" to the detected stack.
+- Multi-platform support for optional roles: `--add-member` and auto-deploy
+  now generate role files for all active platforms (Copilot, Claude, Cursor)
+  with proper frontmatter.
+
+### Fixed
+
+- `DETECTED_STACK` unbound variable crash when deploying to a new (empty)
+  directory where `detect_existing_project()` was never called.
+
 ## [0.4.4] - 2026-04-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
-- New optional roles: **git-specialist** (Git workflows, branch policies, PR hygiene)
+- New optional roles: **git-specialist** (Git workflows, branch policies, PR hygiene),
+  **repo-documenter** (codebase understanding, architecture docs, onboarding guides)
   and **shell-scripting** (Bash/sh automation, cross-platform scripting, ShellCheck).
-- Auto-deploy of optional roles: `git-specialist` is always included;
-  `shell-scripting` is added automatically when `*.sh`/`*.bash`/`*.zsh` files
-  are detected in the project.
+- Auto-deploy of optional roles: `git-specialist` and `repo-documenter` are always
+  included; `shell-scripting` is added automatically when `*.sh`/`*.bash`/`*.zsh`
+  files are detected in the project.
 - Shell detection in `detect_existing_project()`: scans for `*.sh`, `*.bash`,
   `*.zsh` files and adds "Shell" to the detected stack.
 - Multi-platform support for optional roles: `--add-member` and auto-deploy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -553,11 +553,20 @@ Optional roles live in `roles/`. Follow the structure of existing roles:
 
 ```
 roles/
-  my-role.instructions.md   ← role instructions for Copilot/VS Code
+  my-role.instructions.md   ← role instructions (Markdown)
 ```
 
 Each file has YAML frontmatter with `applyTo` and the body in Markdown.
 See `roles/data-engineer.instructions.md` as a reference.
+
+When deployed via `--add-member` or auto-deploy, the wizard generates
+platform-specific files for every active platform:
+
+| Platform | Destination | Extra frontmatter |
+|---|---|---|
+| Copilot | `.github/instructions/<role>.instructions.md` | — |
+| Claude | `.claude/agents/<role>.md` | `name`, `description`, `model`, `tools` |
+| Cursor | `.cursor/agents/<role>.md` | `name`, `description`, `model` |
 
 If the new role makes sense for the general community, open a PR.
 If it's very domain-specific, keep it in your fork or in a local `roles/`.

--- a/README.md
+++ b/README.md
@@ -220,8 +220,10 @@ understudy/
 │       └── team-roster.md
 ├── roles/                       # 🎭 Optional roles catalog
 │   ├── data-engineer.instructions.md
+│   ├── git-specialist.instructions.md
 │   ├── mobile-engineer.instructions.md
 │   ├── ml-engineer.instructions.md
+│   ├── shell-scripting.instructions.md
 │   ├── tech-writer.instructions.md
 │   └── sre.instructions.md
 ├── tests/                       # 🧪 bats test suite
@@ -361,8 +363,10 @@ The `roles/` folder is the **official optional roles catalog** for the system. T
 | Role | When to use it |
 |---|---|
 | 📊 **data-engineer** | ETL/ELT pipelines, data warehouses, streaming, data governance |
+| 🌿 **git-specialist** | Git workflows, branch policies, PR hygiene, release discipline |
 | 📱 **mobile-engineer** | iOS/Android apps, React Native, Flutter |
 | 🤖 **ml-engineer** | ML models, MLOps, LLMs, RAG, responsible AI |
+| 🐚 **shell-scripting** | Bash/sh automation, cross-platform scripting, ShellCheck best practices |
 | 📝 **tech-writer** | Technical documentation, API docs, tutorials, Diataxis |
 | 🧭 **sre** | SLOs, observability, incident response, chaos engineering |
 

--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ The wizard scans up to 3 levels deep to detect technologies:
 | Python | `requirements.txt`, `pyproject.toml`, `setup.py`, `Pipfile` | `Python: services/ml-scoring` |
 | Terraform | `*.tf` | `Terraform: infra/terraform` |
 | Docker | `Dockerfile`, `docker-compose.yml` | `Docker: 4 Dockerfiles` |
+| Shell | `*.sh`, `*.bash`, `*.zsh` | `Shell` (auto-adds shell-scripting role) |
 
 ### Monorepo Support
 
@@ -370,9 +371,14 @@ The `roles/` folder is the **official optional roles catalog** for the system. T
 | 📝 **tech-writer** | Technical documentation, API docs, tutorials, Diataxis |
 | 🧭 **sre** | SLOs, observability, incident response, chaos engineering |
 
-**How to add them:**
+**Auto-deploy:** The wizard always includes `git-specialist`. If shell scripts
+(`*.sh`, `*.bash`, `*.zsh`) are detected in your project, `shell-scripting` is
+added automatically. Both are deployed to every platform you selected (Copilot,
+Claude, Cursor).
 
-1. **From the existing catalog**: `understudy --add-member` → choose from menu
+**How to add more:**
+
+1. **From the existing catalog**: `understudy --add-member` → choose from menu (works with Copilot, Claude and Cursor projects)
 2. **Create a new one**: `understudy --create-role` → saved in `roles/` for reuse
 3. **Manual**: create a file `name.instructions.md` in `roles/` following the existing format
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ understudy/
 │   ├── git-specialist.instructions.md
 │   ├── mobile-engineer.instructions.md
 │   ├── ml-engineer.instructions.md
+│   ├── repo-documenter.instructions.md
 │   ├── shell-scripting.instructions.md
 │   ├── tech-writer.instructions.md
 │   └── sre.instructions.md
@@ -367,14 +368,15 @@ The `roles/` folder is the **official optional roles catalog** for the system. T
 | 🌿 **git-specialist** | Git workflows, branch policies, PR hygiene, release discipline |
 | 📱 **mobile-engineer** | iOS/Android apps, React Native, Flutter |
 | 🤖 **ml-engineer** | ML models, MLOps, LLMs, RAG, responsible AI |
-| 🐚 **shell-scripting** | Bash/sh automation, cross-platform scripting, ShellCheck best practices |
+| � **repo-documenter** | Codebase understanding, architecture docs, onboarding guides |
+| �🐚 **shell-scripting** | Bash/sh automation, cross-platform scripting, ShellCheck best practices |
 | 📝 **tech-writer** | Technical documentation, API docs, tutorials, Diataxis |
 | 🧭 **sre** | SLOs, observability, incident response, chaos engineering |
 
-**Auto-deploy:** The wizard always includes `git-specialist`. If shell scripts
-(`*.sh`, `*.bash`, `*.zsh`) are detected in your project, `shell-scripting` is
-added automatically. Both are deployed to every platform you selected (Copilot,
-Claude, Cursor).
+**Auto-deploy:** The wizard always includes `git-specialist` and
+`repo-documenter`. If shell scripts (`*.sh`, `*.bash`, `*.zsh`) are detected
+in your project, `shell-scripting` is added automatically. All are deployed to
+every platform you selected (Copilot, Claude, Cursor).
 
 **How to add more:**
 

--- a/docs/01-introduction.md
+++ b/docs/01-introduction.md
@@ -74,10 +74,16 @@ add more with `understudy --add-member` or create your own with
 | Role | When to use |
 |---|---|
 | 📊 data-engineer | ETL/ELT, warehouses, streaming, data governance |
+| 🌿 git-specialist | Git workflows, branch policies, PR hygiene, release discipline |
 | 📱 mobile-engineer | iOS, Android, React Native, Flutter |
 | 🤖 ml-engineer | ML/LLMs, RAG, MLOps, responsible AI |
+| 🐚 shell-scripting | Bash/sh automation, cross-platform scripting, ShellCheck |
 | 📝 tech-writer | Docs, API reference, tutorials, Diataxis |
 | 🧭 sre | SLOs, observability, incidents, chaos engineering |
+
+> **Auto-deploy:** `git-specialist` is always included when you run the wizard.
+> `shell-scripting` is added automatically when `*.sh`, `*.bash` or `*.zsh`
+> files are detected in your project.
 
 ## Files Understudy produces
 

--- a/docs/01-introduction.md
+++ b/docs/01-introduction.md
@@ -77,13 +77,14 @@ add more with `understudy --add-member` or create your own with
 | 🌿 git-specialist | Git workflows, branch policies, PR hygiene, release discipline |
 | 📱 mobile-engineer | iOS, Android, React Native, Flutter |
 | 🤖 ml-engineer | ML/LLMs, RAG, MLOps, responsible AI |
+| � repo-documenter | Codebase understanding, architecture docs, onboarding guides |
 | 🐚 shell-scripting | Bash/sh automation, cross-platform scripting, ShellCheck |
 | 📝 tech-writer | Docs, API reference, tutorials, Diataxis |
 | 🧭 sre | SLOs, observability, incidents, chaos engineering |
 
-> **Auto-deploy:** `git-specialist` is always included when you run the wizard.
-> `shell-scripting` is added automatically when `*.sh`, `*.bash` or `*.zsh`
-> files are detected in your project.
+> **Auto-deploy:** `git-specialist` and `repo-documenter` are always included
+> when you run the wizard. `shell-scripting` is added automatically when
+> `*.sh`, `*.bash` or `*.zsh` files are detected in your project.
 
 ## Files Understudy produces
 

--- a/docs/02-quick-start.md
+++ b/docs/02-quick-start.md
@@ -50,8 +50,9 @@ cursor .          # Cursor
   (`split` keeps them in a dedicated file, `embedded` inlines critical rules).
 - If you opted into local-only mode, the affected paths were appended to the
   project's `.gitignore` (see [Configuration → Local-only mode](09-configuration.md#local-only-mode)).
-- Optional roles were auto-deployed: `git-specialist` is always included,
-  and `shell-scripting` is added when shell scripts are detected.
+- Optional roles were auto-deployed: `git-specialist` and `repo-documenter`
+  are always included, and `shell-scripting` is added when shell scripts are
+  detected.
 - Nothing else in your repository was modified.
 
 ## First session, step by step

--- a/docs/02-quick-start.md
+++ b/docs/02-quick-start.md
@@ -50,6 +50,8 @@ cursor .          # Cursor
   (`split` keeps them in a dedicated file, `embedded` inlines critical rules).
 - If you opted into local-only mode, the affected paths were appended to the
   project's `.gitignore` (see [Configuration → Local-only mode](09-configuration.md#local-only-mode)).
+- Optional roles were auto-deployed: `git-specialist` is always included,
+  and `shell-scripting` is added when shell scripts are detected.
 - Nothing else in your repository was modified.
 
 ## First session, step by step
@@ -75,7 +77,7 @@ cursor .          # Cursor
 ## Extending the team
 
 ```bash
-understudy --add-member       # pick from roles/ (data, ML, mobile, SRE, tech-writer)
+understudy --add-member       # pick from roles/ — deploys to all active platforms
 understudy --create-role      # interactive wizard to design a new role
 ```
 

--- a/docs/09-configuration.md
+++ b/docs/09-configuration.md
@@ -77,6 +77,22 @@ After editing `understudy.yaml`, re-run the wizard to regenerate the
 affected files. Existing customizations in your repo are preserved unless
 the file is one of the Understudy-owned templates.
 
+## Optional roles auto-deploy
+
+The wizard automatically deploys certain optional roles from the `roles/`
+catalog:
+
+| Role | Condition |
+|---|---|
+| `git-specialist` | Always included |
+| `shell-scripting` | Included when `*.sh`, `*.bash` or `*.zsh` files are detected |
+
+Auto-deployed roles are generated for every platform you selected (Copilot,
+Claude, Cursor) and the `docs/team-roster.md` is updated automatically.
+
+There is currently no YAML key to disable auto-deploy; the behavior is
+hardcoded in the wizard.
+
 ---
 
 Next: [Troubleshooting and FAQ](10-troubleshooting.md)

--- a/docs/09-configuration.md
+++ b/docs/09-configuration.md
@@ -85,6 +85,7 @@ catalog:
 | Role | Condition |
 |---|---|
 | `git-specialist` | Always included |
+| `repo-documenter` | Always included |
 | `shell-scripting` | Included when `*.sh`, `*.bash` or `*.zsh` files are detected |
 
 Auto-deployed roles are generated for every platform you selected (Copilot,

--- a/roles/git-specialist.instructions.md
+++ b/roles/git-specialist.instructions.md
@@ -1,0 +1,40 @@
+# Git Specialist — Repository Workflow and Governance Instructions
+
+## Identity
+
+You are the Git Specialist of the Understudy team. Your code name is **GitSpecialist**.
+You optimize repository workflows, branch strategy, commit hygiene and policy enforcement.
+Your motto: "Clean history, predictable automation, safe collaboration."
+
+## Expertise
+- **Git internals**: refs, HEAD/index/worktree, merge bases, reflog, bisect
+- **Branching models**: trunk-based, GitFlow, release branches, hotfix strategy
+- **Commit quality**: Conventional Commits, atomic commits, informative commit bodies
+- **Pull requests**: review hygiene, template compliance, change scoping, risk labeling
+- **Repo policies**: branch protection, required checks, CODEOWNERS, signed commits
+- **Release discipline**: SemVer tags, changelog-driven releases, release notes quality
+- **History maintenance**: non-destructive rebases, conflict resolution, cherry-pick strategy
+- **Automation-aware workflows**: GitHub Actions triggers, status checks, merge queue readiness
+
+## How you work
+1. You inspect repository state and branch health before proposing changes
+2. You choose the minimal, safest workflow (branch, commits, PR) to deliver value
+3. You enforce commit and PR standards before merge
+4. You validate CI/check requirements and policy constraints early
+5. You keep history readable and reversible (small atomic commits, clear messages)
+6. You prevent accidental destructive operations unless explicitly approved
+
+## Standards
+- Branch names follow team conventions (`feat/*`, `fix/*`, `docs/*`, `ci/*`, `chore/*`)
+- Every merge to protected branches goes through PR + required checks
+- Commits are atomic, scoped, and use Conventional Commits
+- Tag/release flow follows SemVer and requires changelog alignment
+- Never rewrite published history unless explicitly approved by maintainers
+- Prefer non-interactive, auditable git commands in automation contexts
+- Keep PRs focused: one objective, clear test evidence, clear rollback path
+
+## Team interaction
+- **← Architect / PM**: You receive release scope and branching constraints
+- **→ All engineers**: You define practical git workflow, PR discipline and merge strategy
+- **→ DevOps / CI owners**: You align branch policies with CI checks and release automation
+- **→ Security**: You coordinate policy gates (signed commits, protected branches, reviews)

--- a/roles/repo-documenter.instructions.md
+++ b/roles/repo-documenter.instructions.md
@@ -1,0 +1,51 @@
+# Repo Documenter — Codebase Understanding and Documentation Specialist Instructions
+
+## Identity
+
+You are the Repo Documenter of the Understudy team. Your code name is **RepoDocumenter**.
+You specialize in understanding repository structure, reading code at scale and producing clear, actionable documentation from it.
+Your motto: "Understand first, document second — so the next person never has to reverse-engineer."
+
+## Expertise
+- **Codebase analysis**: directory layout, dependency graphs, entry points, module boundaries
+- **Reverse engineering**: reading unfamiliar code, tracing data flows, identifying patterns and anti-patterns
+- **Documentation generation**: README files, architecture overviews, component catalogs, onboarding guides
+- **Diagrams**: C4 model, dependency graphs, call-flow diagrams, Mermaid, PlantUML
+- **Conventions discovery**: detecting naming patterns, folder conventions, config formats, build systems
+- **Multi-language literacy**: comfortable reading .NET, Node.js, Python, Go, Java, Terraform, shell scripts
+- **Knowledge extraction**: turning tribal knowledge, commit history and PR discussions into persistent docs
+
+## How you work
+1. You scan the full repository tree before diving into any file — structure first, details second
+2. You identify the entry points, build system, test layout and deployment pipeline
+3. You read `docs/`, `README.md`, `CONTRIBUTING.md` and any existing documentation to understand what is already covered
+4. You trace the main data/request flows end-to-end to understand the system behavior
+5. You document findings progressively: high-level overview → module catalog → detailed component docs
+6. You flag undocumented areas, dead code, orphan files and inconsistencies
+7. You keep documentation close to the code it describes (README per module when appropriate)
+
+## Standards
+- Start every documentation effort with a one-paragraph system summary
+- Use directory trees and diagrams to orient the reader before prose
+- Document the "why" (design decisions, trade-offs) not just the "what"
+- Code examples must be real snippets from the repo, not fabricated
+- Cross-reference related docs with relative links
+- Keep language simple: no jargon without definition, no ambiguous pronouns
+- Flag assumptions explicitly ("This assumes PostgreSQL 15+ is running locally")
+- Update docs when the code they describe changes — docs rot is a bug
+
+## Deliverables
+- **Repository overview**: high-level summary, tech stack, directory map, getting started
+- **Architecture docs**: component diagram, data flow, integration points
+- **Module catalog**: purpose, public API, dependencies, configuration of each module
+- **Onboarding guide**: how to clone, install, run, test and deploy for the first time
+- **Decision log entries**: when you discover undocumented architectural decisions
+
+## Team interaction
+- **← Architect**: You receive design context and validate your understanding against their intent
+- **← Backend / Frontend**: You ask clarifying questions and review your docs for accuracy
+- **← DevOps**: You document CI/CD pipelines, environment setup and infrastructure layout
+- **← Git Specialist**: You use commit history and PR descriptions as source material
+- **→ Tech Writer**: You hand off raw technical docs for polishing and audience adaptation
+- **→ PM**: You deliver onboarding guides and system overviews for stakeholder communication
+- **→ All roles**: You maintain the living documentation that every team member relies on

--- a/roles/shell-scripting.instructions.md
+++ b/roles/shell-scripting.instructions.md
@@ -1,0 +1,40 @@
+# Shell Scripting Engineer — Bash/Sh Automation Instructions
+
+## Identity
+
+You are the Shell Scripting Engineer of the Understudy team. Your code name is **ShellScripter**.
+You design robust, portable, maintainable shell automation.
+Your motto: "Small scripts, sharp guarantees, zero surprises."
+
+## Expertise
+- **Shells**: Bash, POSIX sh, dash, zsh compatibility constraints
+- **Portability**: GNU vs BSD tooling differences (sed, awk, grep, date)
+- **Reliability**: `set -euo pipefail`, trap cleanup, strict quoting, error propagation
+- **Safety**: input validation, safe path handling, destructive-command guardrails
+- **Performance**: streaming pipelines, minimizing subshells/process spawning
+- **Tooling**: ShellCheck, shfmt conventions, bats-core testing
+- **Automation**: installers, bootstrap scripts, CI scripts, release scripts
+- **Cross-platform**: Linux, macOS, Git Bash/WSL behavior differences
+
+## How you work
+1. You clarify target shell/runtime first (bash vs POSIX sh)
+2. You prefer simple, explicit control flow and defensive defaults
+3. You implement strict error handling and cleanup traps
+4. You ensure quoting and glob behavior are correct for all inputs
+5. You test critical paths and edge cases with bats where possible
+6. You document assumptions and compatibility constraints in-script
+
+## Standards
+- Use `#!/usr/bin/env bash` only when Bash features are required
+- Quote variable expansions by default (`"$var"`)
+- Avoid unsafe word splitting and unbounded globs
+- Validate external command availability before use
+- Keep scripts idempotent when intended for provisioning/install flows
+- Prefer portable patterns when script must run on Linux + macOS + Git Bash
+- Run ShellCheck and address warnings (or justify exceptions)
+
+## Team interaction
+- **← Backend / DevOps**: You receive automation needs and operational constraints
+- **→ QA**: You provide testable script behavior and edge-case scenarios
+- **→ Security**: You request review on scripts touching secrets or destructive ops
+- **→ Git Specialist**: You align release/install scripts with repository workflow

--- a/tests/unit/detect_existing_project.bats
+++ b/tests/unit/detect_existing_project.bats
@@ -122,6 +122,15 @@ run_detect() {
   [[ "$DETECTED_STACK" == *"Docker"* ]]
 }
 
+# ── Shell scripting ──────────────────────────────────────────────────────────
+
+@test "detects shell scripting projects" {
+  mkdir -p "$TEST_TMP/shell/scripts"
+  touch "$TEST_TMP/shell/scripts/deploy.sh"
+  run_detect "$TEST_TMP/shell"
+  [[ "$DETECTED_STACK" == *"Shell"* ]]
+}
+
 # ── Monorepo ──────────────────────────────────────────────────────────────────
 
 @test "labels as Monorepo when 3+ independent projects found" {

--- a/wizard.sh
+++ b/wizard.sh
@@ -59,7 +59,11 @@ PLATFORM_CURSOR=true
 GIT_LOCAL_CONFIG=false   # gitignore AI config files (agents, instructions, hooks)
 GIT_LOCAL_MEMORY=false   # gitignore session memory files (spec, decisions, session-log)
 
-# Optional roles automation
+# Detection defaults (set properly when detect_existing_project runs)
+DETECTED_STACK=""
+DETECTED_REPO=""
+DETECTED_DESC=""
+DETECTED_COMPONENTS=()
 DETECTED_HAS_SHELL=false
 
 # Colores

--- a/wizard.sh
+++ b/wizard.sh
@@ -1218,10 +1218,11 @@ EOF
     local roster="${TARGET_DIR}/docs/team-roster.md"
     if [[ -f "$roster" ]] && [[ -n "$roster_ref" ]] && ! grep -q "${role_name}" "$roster"; then
         local display_name
-        display_name="$(echo "$role_name" | sed 's/-/ /g' | sed 's/\b\(.\)/\u\1/g')"
-        sed -i "/<!-- new members here -->/a | **${display_name}** | ${display_name} | \`${roster_ref}\` | ✅ Active |" "$roster" 2>/dev/null || \
-            sed -i'' "/<!-- new members here -->/a\\
-| **${display_name}** | ${display_name} | \`${roster_ref}\` | ✅ Active |" "$roster"
+        display_name="$(echo "$role_name" | sed 's/-/ /g' | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2); print}')"
+        local tmp_roster
+        tmp_roster="$(mktemp)"
+        sed "/<!-- new members here -->/a\\
+| **${display_name}** | ${display_name} | \`${roster_ref}\` | ✅ Active |" "$roster" > "$tmp_roster" && mv "$tmp_roster" "$roster"
         success "team-roster.md updated (${role_name})"
     fi
 }
@@ -1413,10 +1414,11 @@ EOF
     local roster="${TARGET_DIR}/docs/team-roster.md"
     if [[ -f "$roster" ]]; then
         local display_name
-        display_name="$(echo "$selected_name" | sed 's/-/ /g' | sed 's/\b\(.\)/\u\1/g')"
-        sed -i "/<!-- new members here -->/a | **${display_name}** | ${display_name} | \`${roster_ref}\` | ✅ Active |" "$roster" 2>/dev/null || \
-            sed -i'' "/<!-- new members here -->/a\\
-| **${display_name}** | ${display_name} | \`${roster_ref}\` | ✅ Active |" "$roster"
+        display_name="$(echo "$selected_name" | sed 's/-/ /g' | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2); print}')"
+        local tmp_roster
+        tmp_roster="$(mktemp)"
+        sed "/<!-- new members here -->/a\\
+| **${display_name}** | ${display_name} | \`${roster_ref}\` | ✅ Active |" "$roster" > "$tmp_roster" && mv "$tmp_roster" "$roster"
         success "team-roster.md updated"
     fi
 

--- a/wizard.sh
+++ b/wizard.sh
@@ -1145,34 +1145,79 @@ deploy_gitignore() {
 add_optional_role_to_project() {
     local role_name="$1"
 
-    # Optional roles currently map to Copilot instruction files.
-    if ! $PLATFORM_COPILOT; then
-        return
-    fi
-
     local src="${ROLES_DIR}/${role_name}.instructions.md"
-    local dst="${TARGET_DIR}/.github/instructions/${role_name}.instructions.md"
 
     if [[ ! -f "$src" ]]; then
         warn "Optional role not found in catalog: ${role_name}"
         return
     fi
 
-    if [[ -f "$dst" ]]; then
-        info "Optional role already present: ${role_name}"
-    else
-        cp "$src" "$dst"
-        success "Optional role added: ${role_name}"
+    local roster_ref=""
+
+    if $PLATFORM_COPILOT; then
+        local dst_copilot="${TARGET_DIR}/.github/instructions/${role_name}.instructions.md"
+        if [[ -f "$dst_copilot" ]]; then
+            info "Optional role already present (Copilot): ${role_name}"
+        else
+            cp "$src" "$dst_copilot"
+            success "Optional role added (Copilot): ${role_name}"
+        fi
+        [[ -z "$roster_ref" ]] && roster_ref=".github/instructions/${role_name}.instructions.md"
+    fi
+
+    if $PLATFORM_CLAUDE; then
+        local dst_claude="${TARGET_DIR}/.claude/agents/${role_name}.md"
+        if [[ -f "$dst_claude" ]]; then
+            info "Optional role already present (Claude): ${role_name}"
+        else
+            cat > "$dst_claude" << EOF
+---
+name: ${role_name}
+description: "Optional specialist role: ${role_name}"
+model: ${MODEL_BACKEND}
+tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+---
+
+EOF
+            cat "$src" >> "$dst_claude"
+            success "Optional role added (Claude): ${role_name}"
+        fi
+        [[ -z "$roster_ref" ]] && roster_ref=".claude/agents/${role_name}.md"
+    fi
+
+    if $PLATFORM_CURSOR; then
+        local dst_cursor="${TARGET_DIR}/.cursor/agents/${role_name}.md"
+        if [[ -f "$dst_cursor" ]]; then
+            info "Optional role already present (Cursor): ${role_name}"
+        else
+            cat > "$dst_cursor" << EOF
+---
+name: ${role_name}
+description: "Optional specialist role: ${role_name}"
+model: ${MODEL_BACKEND}
+---
+
+EOF
+            cat "$src" >> "$dst_cursor"
+            success "Optional role added (Cursor): ${role_name}"
+        fi
+        [[ -z "$roster_ref" ]] && roster_ref=".cursor/agents/${role_name}.md"
     fi
 
     # Keep team-roster in sync (idempotent)
     local roster="${TARGET_DIR}/docs/team-roster.md"
-    if [[ -f "$roster" ]] && ! grep -q "\.github/instructions/${role_name}\.instructions\.md" "$roster"; then
+    if [[ -f "$roster" ]] && [[ -n "$roster_ref" ]] && ! grep -q "${role_name}" "$roster"; then
         local display_name
         display_name="$(echo "$role_name" | sed 's/-/ /g' | sed 's/\b\(.\)/\u\1/g')"
-        sed -i "/<!-- new members here -->/a | **${display_name}** | ${display_name} | \`.github/instructions/${role_name}.instructions.md\` | ✅ Active |" "$roster" 2>/dev/null || \
+        sed -i "/<!-- new members here -->/a | **${display_name}** | ${display_name} | \`${roster_ref}\` | ✅ Active |" "$roster" 2>/dev/null || \
             sed -i'' "/<!-- new members here -->/a\\
-| **${display_name}** | ${display_name} | \`.github/instructions/${role_name}.instructions.md\` | ✅ Active |" "$roster"
+| **${display_name}** | ${display_name} | \`${roster_ref}\` | ✅ Active |" "$roster"
         success "team-roster.md updated (${role_name})"
     fi
 }
@@ -1289,18 +1334,74 @@ add_team_member() {
 
     ask "Project directory where to add the member" TARGET_DIR
 
-    if [[ ! -d "${TARGET_DIR}/.github/instructions" ]]; then
+    local has_copilot=false has_claude=false has_cursor=false
+    [[ -d "${TARGET_DIR}/.github/instructions" ]] && has_copilot=true
+    [[ -d "${TARGET_DIR}/.claude/agents" ]] && has_claude=true
+    [[ -d "${TARGET_DIR}/.cursor/agents" ]] && has_cursor=true
+
+    if ! $has_copilot && ! $has_claude && ! $has_cursor; then
         error "This does not look like an Understudy project. Run the wizard first."
         exit 1
     fi
 
-    local dest="${TARGET_DIR}/.github/instructions/${selected_name}.instructions.md"
-    if [[ -f "$dest" ]]; then
+    local copied_any=false
+    local roster_ref=""
+
+    if $has_copilot; then
+        local dest_copilot="${TARGET_DIR}/.github/instructions/${selected_name}.instructions.md"
+        if [[ ! -f "$dest_copilot" ]]; then
+            cp "$selected_file" "$dest_copilot"
+            copied_any=true
+            [[ -z "$roster_ref" ]] && roster_ref=".github/instructions/${selected_name}.instructions.md"
+        fi
+    fi
+
+    if $has_claude; then
+        local dest_claude="${TARGET_DIR}/.claude/agents/${selected_name}.md"
+        if [[ ! -f "$dest_claude" ]]; then
+            cat > "$dest_claude" << EOF
+---
+name: ${selected_name}
+description: "Optional specialist role: ${selected_name}"
+model: ${MODEL_BACKEND}
+tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+---
+
+EOF
+            cat "$selected_file" >> "$dest_claude"
+            copied_any=true
+            [[ -z "$roster_ref" ]] && roster_ref=".claude/agents/${selected_name}.md"
+        fi
+    fi
+
+    if $has_cursor; then
+        local dest_cursor="${TARGET_DIR}/.cursor/agents/${selected_name}.md"
+        if [[ ! -f "$dest_cursor" ]]; then
+            cat > "$dest_cursor" << EOF
+---
+name: ${selected_name}
+description: "Optional specialist role: ${selected_name}"
+model: ${MODEL_BACKEND}
+---
+
+EOF
+            cat "$selected_file" >> "$dest_cursor"
+            copied_any=true
+            [[ -z "$roster_ref" ]] && roster_ref=".cursor/agents/${selected_name}.md"
+        fi
+    fi
+
+    if ! $copied_any; then
         warn "Role ${selected_name} already exists in this project."
         return
     fi
 
-    cp "$selected_file" "$dest"
     success "Role '${selected_name}' added to ${TARGET_DIR}"
 
     # Update team-roster.md
@@ -1308,13 +1409,13 @@ add_team_member() {
     if [[ -f "$roster" ]]; then
         local display_name
         display_name="$(echo "$selected_name" | sed 's/-/ /g' | sed 's/\b\(.\)/\u\1/g')"
-        sed -i "/<!-- new members here -->/a | **${display_name}** | ${display_name} | \`.github/instructions/${selected_name}.instructions.md\` | ✅ Active |" "$roster" 2>/dev/null || \
+        sed -i "/<!-- new members here -->/a | **${display_name}** | ${display_name} | \`${roster_ref}\` | ✅ Active |" "$roster" 2>/dev/null || \
             sed -i'' "/<!-- new members here -->/a\\
-| **${display_name}** | ${display_name} | \`.github/instructions/${selected_name}.instructions.md\` | ✅ Active |" "$roster"
+| **${display_name}** | ${display_name} | \`${roster_ref}\` | ✅ Active |" "$roster"
         success "team-roster.md updated"
     fi
 
-    info "Activate the new agent in Copilot CLI with: /instructions"
+    info "Member added for detected platform(s). Activate it from your tool's agent/instructions flow."
 }
 
 # ─── Create custom role ─────────────────────────────────────

--- a/wizard.sh
+++ b/wizard.sh
@@ -1227,8 +1227,9 @@ EOF
 }
 
 deploy_default_optional_roles() {
-    # Always include repository workflow expertise by default.
+    # Always include repository workflow and documentation expertise by default.
     add_optional_role_to_project "git-specialist"
+    add_optional_role_to_project "repo-documenter"
 
     # Auto-add shell scripting specialist on scripting-heavy repositories.
     local stack_lc

--- a/wizard.sh
+++ b/wizard.sh
@@ -59,6 +59,9 @@ PLATFORM_CURSOR=true
 GIT_LOCAL_CONFIG=false   # gitignore AI config files (agents, instructions, hooks)
 GIT_LOCAL_MEMORY=false   # gitignore session memory files (spec, decisions, session-log)
 
+# Optional roles automation
+DETECTED_HAS_SHELL=false
+
 # Colores
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -414,6 +417,7 @@ detect_existing_project() {
     DETECTED_STACK=""
     DETECTED_REPO=""
     DETECTED_COMPONENTS=()
+    DETECTED_HAS_SHELL=false
     EXISTING_MODE="directory"
 
     local is_project=false
@@ -425,6 +429,7 @@ detect_existing_project() {
     local has_angular=false
     local has_terraform=false
     local has_docker=false
+    local has_shell=false
 
     # Already an Understudy project?
     if [[ -f "${dir}/AGENTS.md" ]] && [[ -d "${dir}/.github/instructions" ]]; then
@@ -570,6 +575,15 @@ detect_existing_project() {
         is_project=true
     fi
 
+    # ── Shell scripting ──
+    local shell_count
+    shell_count=$(find "$dir" -maxdepth 3 \( -name "*.sh" -o -name "*.bash" -o -name "*.zsh" \) -not -path "*/.git/*" -not -path "*/node_modules/*" 2>/dev/null | wc -l)
+    if [[ $shell_count -gt 0 ]]; then
+        DETECTED_COMPONENTS+=("Shell scripting: ${shell_count} script(s)")
+        has_shell=true
+        is_project=true
+    fi
+
     # ── Build DETECTED_STACK summary ──
     local stack_parts=()
     if [[ $dotnet_count -gt 1 ]]; then
@@ -595,6 +609,7 @@ detect_existing_project() {
 
     $has_terraform && stack_parts+=("Terraform")
     $has_docker && stack_parts+=("Docker")
+    $has_shell && stack_parts+=("Shell")
 
     # Join with " + "
     local joined=""
@@ -616,6 +631,8 @@ detect_existing_project() {
     if $is_project && [[ "$EXISTING_MODE" != "understudy" ]]; then
         EXISTING_MODE="project"
     fi
+
+    DETECTED_HAS_SHELL=$has_shell
 }
 
 # ─── Gather project information ─────────────────────────────
@@ -1123,6 +1140,56 @@ deploy_gitignore() {
     success ".gitignore updated"
 }
 
+# ─── Optional roles automation ──────────────────────────────
+
+add_optional_role_to_project() {
+    local role_name="$1"
+
+    # Optional roles currently map to Copilot instruction files.
+    if ! $PLATFORM_COPILOT; then
+        return
+    fi
+
+    local src="${ROLES_DIR}/${role_name}.instructions.md"
+    local dst="${TARGET_DIR}/.github/instructions/${role_name}.instructions.md"
+
+    if [[ ! -f "$src" ]]; then
+        warn "Optional role not found in catalog: ${role_name}"
+        return
+    fi
+
+    if [[ -f "$dst" ]]; then
+        info "Optional role already present: ${role_name}"
+    else
+        cp "$src" "$dst"
+        success "Optional role added: ${role_name}"
+    fi
+
+    # Keep team-roster in sync (idempotent)
+    local roster="${TARGET_DIR}/docs/team-roster.md"
+    if [[ -f "$roster" ]] && ! grep -q "\.github/instructions/${role_name}\.instructions\.md" "$roster"; then
+        local display_name
+        display_name="$(echo "$role_name" | sed 's/-/ /g' | sed 's/\b\(.\)/\u\1/g')"
+        sed -i "/<!-- new members here -->/a | **${display_name}** | ${display_name} | \`.github/instructions/${role_name}.instructions.md\` | ✅ Active |" "$roster" 2>/dev/null || \
+            sed -i'' "/<!-- new members here -->/a\\
+| **${display_name}** | ${display_name} | \`.github/instructions/${role_name}.instructions.md\` | ✅ Active |" "$roster"
+        success "team-roster.md updated (${role_name})"
+    fi
+}
+
+deploy_default_optional_roles() {
+    # Always include repository workflow expertise by default.
+    add_optional_role_to_project "git-specialist"
+
+    # Auto-add shell scripting specialist on scripting-heavy repositories.
+    local stack_lc
+    stack_lc="$(to_lower "${TECH_STACK} ${DETECTED_STACK}")"
+    if $DETECTED_HAS_SHELL || [[ "$stack_lc" == *"bash"* ]] || [[ "$stack_lc" == *"shell"* ]] || [[ "$stack_lc" == *"scripting"* ]]; then
+        add_optional_role_to_project "shell-scripting"
+        info "Auto-selected optional role: shell-scripting"
+    fi
+}
+
 # ─── Deployment orchestrator ───────────────────────────────
 
 deploy_team() {
@@ -1154,6 +1221,9 @@ deploy_team() {
     deploy_file "${TEMPLATES_DIR}/docs/decisions.md" "${TARGET_DIR}/docs/decisions.md"
     deploy_file "${TEMPLATES_DIR}/docs/session-log.md" "${TARGET_DIR}/docs/session-log.md"
     deploy_file "${TEMPLATES_DIR}/docs/team-roster.md" "${TARGET_DIR}/docs/team-roster.md"
+
+    # Optional roles defaults and auto-detection
+    deploy_default_optional_roles
 
     # Copy config to project for local override
     if [[ -f "$DEFAULT_CONFIG" ]] && [[ ! -f "${TARGET_DIR}/understudy.yaml" ]]; then


### PR DESCRIPTION
## Description

Adds two new optional roles to `roles/`:
- `git-specialist.instructions.md`
- `shell-scripting.instructions.md`

These roles are designed to improve repository interaction precision and scripting quality, reducing unnecessary iterations and token usage in day-to-day workflow.

---

## Type of change

- [ ] 🐛 `fix` — bug fix
- [x] ✨ `feat` — new functionality
- [x] 📝 `docs` — documentation only
- [ ] ♻️ `refactor` — refactoring without behavior change
- [ ] 🧪 `test` — add or fix tests
- [ ] ⚙️ `ci` — CI/CD changes
- [ ] 🔧 `chore` — maintenance
- [ ] 💥 Breaking change (breaks compatibility with previous versions)

---

## What changes?

- Added `roles/git-specialist.instructions.md`:
  - Git internals, branch models, PR discipline, repository policy awareness
  - Release/tag/changelog workflow alignment
  - Safe, auditable git operation standards
- Added `roles/shell-scripting.instructions.md`:
  - Bash/sh portability, strict mode, quoting/splitting safety
  - Cross-platform script behavior (Linux/macOS/Git Bash)
  - ShellCheck-oriented standards and automation practices
- Updated `README.md`:
  - Included both roles in the repository structure block
  - Added both roles to the “Included optional roles” table

---

## How to test

```bash
# List optional roles
ls roles/

# Verify new role files exist
test -f roles/git-specialist.instructions.md
test -f roles/shell-scripting.instructions.md

# Check docs mention them
grep -n "git-specialist\|shell-scripting" README.md
```

---

## Checklist

- [x] Commits follow Conventional Commits
- [ ] `CHANGELOG.md` updated in the `[Unreleased]` section
- [x] `bash -n wizard.sh` passes without errors
- [x] ShellCheck passes locally (or new warnings are justified)
- [x] Affected documentation is updated
