### PR TITLE
release: v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-04-28
+
 ### Added
 
 - New optional roles: **git-specialist** (Git workflows, branch policies, PR hygiene),
@@ -25,6 +27,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - `DETECTED_STACK` unbound variable crash when deploying to a new (empty)
   directory where `detect_existing_project()` was never called.
+- Portable `sed`/`awk` usage for macOS (BSD) compatibility in team-roster
+  updates and role title-casing.
 
 ## [0.4.4] - 2026-04-28
 


### PR DESCRIPTION
## Description
Release v0.5.0 — changelog entry for new roles feature.

## Type of change
- [x] Release

## What changes?
- Moves [Unreleased] section to [0.5.0] - 2026-04-28
- Adds macOS sed/awk fix to changelog

## How to test
1. Review CHANGELOG.md diff
2. CI passes

## Checklist
- [x] CHANGELOG.md updated
- [x] Tests pass
- [x] No breaking changes