### PR TITLE
release: v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-04-28
+
 ### Added
 
 - `--here` flag: deploy Understudy directly in the current directory using


### PR DESCRIPTION
## Description

Release v0.5.1 — promotes the `[Unreleased]` entry from `CHANGELOG.md` to the new `[0.5.1]` section. No code changes.

Closes #

---

## Type of change

- [x] ⚙️ `ci` — CI/CD changes
- [x] 🔧 `chore` — maintenance

---

## What changes?

- `CHANGELOG.md`: open new `[0.5.1] - 2026-04-28` section with the entries from `[Unreleased]`; `[Unreleased]` is now empty again.

---

## How to test

```bash
# Verify CHANGELOG only:
head -25 CHANGELOG.md
```

After merge: tag `v0.5.1` on `main` and create the GitHub release.

---

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] `CHANGELOG.md` updated in the `[Unreleased]` section
- [x] `bash -n wizard.sh` passes without errors
- [x] ShellCheck passes locally (or new warnings are justified)
- [x] Affected documentation is updated
- [ ] If it's a new role: follows the structure of `roles/data-engineer.instructions.md` (n/a)
