### PR TITLE
fix(release): include templates/.github in tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,12 +52,11 @@ jobs:
           version="${{ steps.version.outputs.version }}"
           archive="understudy-${version}.tar.gz"
 
-          # Pack only what users need — no tests, no CI, no dev tooling
+          # Pack only what users need — no tests, no CI, no dev tooling.
+          # NOTE: do NOT use --exclude='.github' here — it would also strip
+          # templates/.github/ (the Copilot templates). The listed paths
+          # already omit the repo's top-level .git, .github and tests dirs.
           tar -czf "$archive" \
-            --exclude='.git' \
-            --exclude='.github' \
-            --exclude='tests' \
-            --exclude='run_tests.sh' \
             --exclude='*.tar.gz' \
             wizard.sh \
             install.sh \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.5.3] - 2026-04-28
+
+### Fixed
+
+- Release tarball was missing `templates/.github/` (Copilot templates) due to
+  an over-broad `--exclude='.github'` flag in the release workflow that also
+  matched the nested `templates/.github/` directory. As a result, installs of
+  v0.5.0–v0.5.2 via the published tarball failed at deploy time with
+  `Missing Copilot template: .github/copilot-instructions.md`. The packaging
+  step now only excludes the temporary archive itself; the explicit list of
+  paths already keeps unwanted top-level dirs (`.git`, `.github`, `tests`)
+  out of the tarball.
+
 ## [0.5.2] - 2026-04-28
 
 ### Changed


### PR DESCRIPTION
## Description

Hotfix: the published release tarballs (v0.5.0, v0.5.1, v0.5.2) were missing `templates/.github/` because the release workflow used `tar --exclude='.github'`, which matches `.github/` at **any** depth — stripping the bundled Copilot templates. Installs via `install.sh` therefore failed at deploy time with:

```
✖  Missing Copilot template: .github/copilot-instructions.md
```

## Type of change

- [ ] New feature
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / chore

## What changes?

- `.github/workflows/release.yml`: removed the broad `--exclude` flags. The explicit list of packed paths (`wizard.sh`, `install.sh`, `understudy.yaml`, `templates`, `roles`, `docs`, `README.md`, `CHANGELOG.md`, `LICENSE`) already keeps the repo's top-level `.git`, `.github`, `tests` out of the tarball, so the excludes were unnecessary and actively harmful for the nested `templates/.github/`.
- `CHANGELOG.md`: `[0.5.3]` entry under `Fixed`.

## How to test

After this PR is merged and v0.5.3 is tagged, the release tarball should list `templates/.github/copilot-instructions.md`:

```bash
curl -fsSL https://github.com/erniker/understudy/releases/download/v0.5.3/understudy-v0.5.3.tar.gz \
  | tar -tz | grep templates/.github
```

End-to-end:

```bash
curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash
mkdir /tmp/demo && cd /tmp/demo
understudy --here --yes
```

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my own code
- [x] I have updated the CHANGELOG.md
- [x] I have run the test suite locally and all tests pass
