### PR TITLE
fix(wizard): never silently auto-update on EOF in confirm prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.5.4] - 2026-04-28
+
+### Fixed
+
+- Auto-update prompt could trigger an unattended update. The "New
+  Understudy version available — do you want to update now?" prompt used
+  `confirm` with a `[Y/n]` default of "yes" *and* treated empty/EOF input
+  as confirmation, so any environment that silently closed stdin (some
+  PowerShell wrappers, non-interactive launchers, certain `bash -c`
+  invocations) auto-accepted the update without the user pressing
+  anything.
+  - `confirm` now takes an explicit second argument for the default and
+    only returns success on an explicit `y`/`yes` answer or when the
+    default itself is `Y`. Empty input or EOF resolves to the provided
+    default.
+  - The auto-update call now passes `"N"` as the default so the prompt is
+    rendered as `[y/N]` and any unanswered case continues with the
+    installed version. Manual updates via the installer one-liner are
+    unaffected.
+
 ## [0.5.3] - 2026-04-28
 
 ### Fixed

--- a/wizard.sh
+++ b/wizard.sh
@@ -238,11 +238,33 @@ ask() {
     fi
 }
 
+# Prompt the user for a yes/no confirmation.
+#
+# Behavior:
+# - Returns 0 only when the resolved answer is "y" / "yes" (case-insensitive).
+# - Empty input or EOF falls back to the second argument (defaults to "Y" so
+#   non-destructive prompts keep their previous "press Enter to accept"
+#   semantics, including non-interactive runs that pipe input and let stdin
+#   close after the last expected answer).
+#
+# For destructive prompts (update, delete, overwrite) callers should pass
+# `"N"` as the second argument so that an unanswered prompt — including the
+# case where the read silently fails because the script is wrapped in a
+# non-interactive launcher — cannot trigger the destructive action.
 confirm() {
     local prompt="$1"
-    echo -ne "  ${YELLOW}?${NC}  ${prompt} ${CYAN}[Y/n]${NC}: "
-    read -r answer
-    [[ "$(to_lower "$answer")" != "n" ]]
+    local default="${2:-Y}"
+    local default_label="[Y/n]"
+    [[ "$(to_lower "$default")" == "n" ]] && default_label="[y/N]"
+
+    echo -ne "  ${YELLOW}?${NC}  ${prompt} ${CYAN}${default_label}${NC}: "
+
+    local answer=""
+    # On EOF `read` returns non-zero and leaves $answer empty; in either case
+    # we let the default resolve the answer below.
+    IFS= read -r answer || true
+    answer="${answer:-$default}"
+    [[ "$(to_lower "$answer")" == "y" || "$(to_lower "$answer")" == "yes" ]]
 }
 
 # ─── Version and update check ───────────────────────────────
@@ -306,7 +328,11 @@ check_for_updates() {
 
     if version_is_newer "$latest_version" "$current_version"; then
         warn "New Understudy version available: ${latest_version} (current: ${current_version})"
-        if confirm "Do you want to update now?"; then
+        # Default to "N": never auto-update silently. If for any reason the
+        # prompt cannot be answered (EOF, wrapper closing stdin, etc.) the
+        # wizard simply continues with the installed version and the user
+        # can update manually whenever they want.
+        if confirm "Do you want to update now?" "N"; then
             step "Updating Understudy"
             if curl -fsSL "$UPDATE_INSTALL_URL" | bash; then
                 success "Update completed. Restarting Understudy..."


### PR DESCRIPTION
## Description

Auto-update prompt could silently update Understudy. The `[Y/n]` confirmation used by `check_for_updates` defaulted to "yes" and treated **empty input or EOF as confirmation**, so any wrapper that closed stdin (some PowerShell launchers, non-interactive contexts, certain `bash -c` chains) auto-accepted the update without the user pressing anything.

## Type of change

- [ ] New feature
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / chore

## What changes?

- `wizard.sh`:
  - `confirm()` now takes an explicit second argument for the default (`"Y"` or `"N"`). It only returns success when the resolved answer is `y`/`yes` (case-insensitive); empty input or EOF falls back to the supplied default. The prompt label adapts: `[Y/n]` for `Y` default, `[y/N]` for `N` default.
  - `check_for_updates` now calls `confirm "Do you want to update now?" "N"`. Updates are never applied unless the user explicitly types `y`/`yes`. All seven other `confirm` callers keep their previous behaviour because they default to `"Y"`.
- `CHANGELOG.md`: `[0.5.4]` entry under `Fixed`.

## How to test

```bash
# Behaviour matrix (all five cases verified locally):
#   default=N + Enter           → REFUSED
#   default=N + EOF             → REFUSED
#   default=N + "y"             → CONFIRMED
#   default=Y + "n"             → REFUSED
#   default=Y + Enter           → CONFIRMED  (existing flows preserved)

./run_tests.sh   # 188 bats tests still pass
```

End-to-end: pipe an empty stdin into the wizard and verify the update prompt is **rejected**:

```bash
UNDERSTUDY_SKIP_UPDATE_CHECK=0 understudy </dev/null
# → "New Understudy version available …"
# → "Do you want to update now? [y/N]:"
# → no auto-update; the wizard simply continues with the installed version.
```

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my own code
- [x] I have updated the CHANGELOG.md
- [x] I have run the test suite locally and all tests pass
- [x] I have manually verified the new behaviour
