### PR TITLE
fix(wizard): update prompt waits on /dev/tty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.5.5] - 2026-04-29
+
+### Fixed
+
+- Auto-update prompt now actually waits for the user to answer. v0.5.4
+  prevented silent auto-update by defaulting to `N` on EOF, but in
+  environments where the script's stdin is closed by an outer wrapper
+  the prompt received an instant EOF and resolved to `N` without giving
+  the user a chance to type. `check_for_updates` now reads the answer
+  directly from `/dev/tty`, so any buffered or closed stdin cannot
+  pre-answer the prompt. If no controlling terminal is available the
+  wizard skips the update with an explicit warning instead of guessing.
+
 ## [0.5.4] - 2026-04-28
 
 ### Fixed

--- a/wizard.sh
+++ b/wizard.sh
@@ -328,19 +328,36 @@ check_for_updates() {
 
     if version_is_newer "$latest_version" "$current_version"; then
         warn "New Understudy version available: ${latest_version} (current: ${current_version})"
-        # Default to "N": never auto-update silently. If for any reason the
-        # prompt cannot be answered (EOF, wrapper closing stdin, etc.) the
-        # wizard simply continues with the installed version and the user
-        # can update manually whenever they want.
-        if confirm "Do you want to update now?" "N"; then
-            step "Updating Understudy"
-            if curl -fsSL "$UPDATE_INSTALL_URL" | bash; then
-                success "Update completed. Restarting Understudy..."
-                exec "$0" "$@"
-            else
-                warn "Update failed. Continuing with current version (${current_version})."
-            fi
+
+        # Read the answer directly from the controlling terminal so that any
+        # buffered input on stdin (caused by wrappers, here-docs, leftover
+        # bytes from previous reads, etc.) cannot pre-answer this prompt.
+        # The wizard explicitly waits here for the user to type y/N.
+        local answer=""
+        echo -ne "  ${YELLOW}?${NC}  Do you want to update now? ${CYAN}[y/N]${NC}: "
+        if [[ -r /dev/tty ]]; then
+            IFS= read -r answer < /dev/tty || answer=""
+        else
+            # No controlling terminal available — do not auto-update.
+            echo ""
+            warn "No interactive terminal detected; skipping update."
+            return 0
         fi
+
+        case "$(to_lower "${answer:-n}")" in
+            y|yes)
+                step "Updating Understudy"
+                if curl -fsSL "$UPDATE_INSTALL_URL" | bash; then
+                    success "Update completed. Restarting Understudy..."
+                    exec "$0" "$@"
+                else
+                    warn "Update failed. Continuing with current version (${current_version})."
+                fi
+                ;;
+            *)
+                info "Continuing with the installed version (${current_version})."
+                ;;
+        esac
     fi
 
     return 0


### PR DESCRIPTION
## Description

v0.5.4 stopped silent auto-updates by defaulting `confirm` to `N` on EOF, but
in environments where the script's stdin is closed by an outer wrapper the
auto-update prompt received an instant EOF and resolved to `N` **without
giving the user a chance to type**. The user reported: they want the wizard
to actually ask and **wait** for an answer.

This PR makes `check_for_updates` read the answer directly from `/dev/tty`,
so any closed/buffered stdin cannot pre-answer the prompt. The prompt blocks
until the user types `y` or `N`. If `/dev/tty` is unavailable (truly
non-interactive environment), the wizard skips the update with an explicit
warning instead of guessing.

The generic `confirm` helper is unchanged, so the bats test suite (which
drives prompts via stdin) is unaffected.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## What changes?

- `wizard.sh` — `check_for_updates` now reads y/N directly from `/dev/tty`
  instead of going through `confirm`. Falls back to a warning + skip when no
  controlling terminal is available.
- `CHANGELOG.md` — adds `[0.5.5] - 2026-04-29` Fixed entry.

## How to test

```bash
bash -n wizard.sh   # syntax check
./run_tests.sh      # 188 bats tests still pass
# Manual: simulate closed stdin
bash wizard.sh --here </dev/null
# Expected: warns "No interactive terminal detected" and continues,
# instead of silently auto-answering N.
# Manual: real terminal
bash wizard.sh --here
# Expected: prompt blocks until you press y/N + Enter.
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (CHANGELOG)
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published
