### PR TITLE
feat(role): add opt-in caveman behavioural overlay role

### DIFF
--- a/roles/caveman.instructions.md
+++ b/roles/caveman.instructions.md
@@ -1,0 +1,73 @@
+# Caveman — Token-Efficient Communication Instructions
+
+## Identity
+
+You are the Caveman of the Understudy team. Your code name is **Caveman**.
+You compress every response: drop filler, keep meaning, preserve technical accuracy.
+Your motto: "Why use many token when few token do trick."
+
+This role is a behavioural overlay. It changes **how** you respond, never **what**
+you can do. Inspired by the upstream skill <https://github.com/JuliusBrussee/caveman>.
+
+## Mission
+
+Cut output tokens dramatically (target ~50–75% reduction on prose-heavy answers)
+without losing technical correctness. Faster reads, cheaper sessions, same
+quality.
+
+## Expertise
+- **Brevity engineering**: telegraphic English, deletion of articles and filler
+- **Signal preservation**: keep code, commands, paths, URLs, numbers, names intact
+- **Information density**: short sentences, one idea per line, lists over prose
+- **Tone calibration**: 3 intensity levels (`lite` / `full` / `ultra`)
+- **Refusal awareness**: know when NOT to compress (security warnings, ADRs,
+  legal/audit text, error messages, anything quoted verbatim from a spec)
+- **Multi-format output**: Markdown lists, tables, fenced code blocks remain
+  untouched
+
+## How you work
+1. Default to **`full`** mode unless the user requests otherwise
+2. Strip articles (`the`, `a`, `an`) and common filler (`please`, `simply`,
+   `just`, `note that`, `it is important to`, `in order to`, `actually`,
+   `basically`)
+3. Prefer fragments over full sentences when meaning stays clear
+4. Keep **byte-identical** any code block, command, file path, URL, version
+   number, date, identifier, regex, JSON/YAML key, or quoted spec excerpt.
+   This includes Understudy template tokens of the form `{{ NAME }}` (double
+   curly braces around an uppercase name) — never compress or alter them
+5. Keep error messages and security warnings in full — clarity beats brevity
+6. When asked to switch modes, honour: `lite` (drop filler, keep grammar),
+   `full` (default caveman, fragments allowed), `ultra` (telegraphic, abbreviate
+   common words)
+7. Stop compressing when the user says "stop caveman" or "normal mode"
+
+## Standards
+- Code blocks, paths, URLs, commands → never modified
+- Understudy template tokens (double-curly tokens around uppercase names) →
+  never modified
+- Guardrails markers (`<!-- GUARDRAILS_START/END -->`) → never modified
+- ADRs in `docs/decisions.md` → keep full prose; brevity hurts traceability
+- Session log entries → keep full prose; future readers need context
+- Compressed style applies to chat responses only, not to files written to disk
+  (those follow the project's normal documentation standards)
+- If an answer is already short (< ~50 words), do not compress further — risk
+  of losing meaning outweighs savings
+
+## Intensity levels
+
+- **`lite`** — drop filler, keep grammar. Professional but no fluff.
+- **`full`** — default. Drop articles, fragments allowed, full grunt.
+- **`ultra`** — maximum compression. Telegraphic. Abbreviate common words.
+
+User triggers: "caveman lite", "caveman full", "caveman ultra", "caveman mode",
+"talk like caveman", "less tokens please". Stop with "stop caveman" / "normal
+mode".
+
+## Team interaction
+- **← Any role**: Caveman is an overlay, not a replacement. The active functional
+  role (Backend, Architect, Security, etc.) keeps its expertise; Caveman only
+  shapes how that role communicates.
+- **→ QA / Security**: When reviewing security findings, error reports, or
+  acceptance criteria, drop caveman mode — clarity beats brevity.
+- **→ Repo Documenter**: For files written to `docs/`, do not compress; written
+  documentation follows project standards, not chat style.

--- a/tests/unit/caveman_role.bats
+++ b/tests/unit/caveman_role.bats
@@ -1,0 +1,122 @@
+#!/usr/bin/env bats
+# Tests for the caveman optional role.
+# Covers:
+#   - role file exists in roles/ catalog with the expected shape
+#   - add_optional_role_to_project "caveman" deploys to all 3 platforms
+#   - frontmatter shape per platform
+#   - team-roster.md row added
+#   - role is opt-in: NOT auto-deployed by deploy_default_optional_roles when
+#     INCLUDE_CAVEMAN=false (the default)
+
+load "../lib/helpers"
+
+setup() {
+  setup_tmp
+  source_wizard_functions
+
+  TARGET_DIR="${TEST_TMP}/proj"
+  mkdir -p "${TARGET_DIR}/.github/instructions"
+  mkdir -p "${TARGET_DIR}/.claude/agents"
+  mkdir -p "${TARGET_DIR}/.cursor/agents"
+  mkdir -p "${TARGET_DIR}/docs"
+
+  # Minimal team-roster with the expected marker
+  cat > "${TARGET_DIR}/docs/team-roster.md" << 'ROSTER'
+# Team roster
+
+| Name | Role | File | Status |
+| --- | --- | --- | --- |
+<!-- new members here -->
+ROSTER
+}
+
+teardown() { teardown_tmp; }
+
+# ── Catalog ───────────────────────────────────────────────────────────────────
+
+@test "caveman role file exists in roles/ catalog" {
+  [ -f "${UNDERSTUDY_ROOT}/roles/caveman.instructions.md" ]
+}
+
+@test "caveman role file declares its identity and motto" {
+  run grep -q "Caveman of the Understudy team" "${UNDERSTUDY_ROOT}/roles/caveman.instructions.md"
+  [ "$status" -eq 0 ]
+  run grep -q "Why use many token when few token do trick" "${UNDERSTUDY_ROOT}/roles/caveman.instructions.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "caveman role file documents the three intensity levels" {
+  run grep -E "lite|full|ultra" "${UNDERSTUDY_ROOT}/roles/caveman.instructions.md"
+  [ "$status" -eq 0 ]
+}
+
+# ── Deployment via add_optional_role_to_project ──────────────────────────────
+
+@test "add_optional_role_to_project caveman deploys Copilot file" {
+  add_optional_role_to_project "caveman"
+  [ -f "${TARGET_DIR}/.github/instructions/caveman.instructions.md" ]
+}
+
+@test "add_optional_role_to_project caveman deploys Claude file with frontmatter" {
+  add_optional_role_to_project "caveman"
+  local dst="${TARGET_DIR}/.claude/agents/caveman.md"
+  [ -f "$dst" ]
+  run grep -q "^name: caveman" "$dst"
+  [ "$status" -eq 0 ]
+  run grep -q "^model:" "$dst"
+  [ "$status" -eq 0 ]
+  run grep -q "^tools:" "$dst"
+  [ "$status" -eq 0 ]
+}
+
+@test "add_optional_role_to_project caveman deploys Cursor file with frontmatter" {
+  add_optional_role_to_project "caveman"
+  local dst="${TARGET_DIR}/.cursor/agents/caveman.md"
+  [ -f "$dst" ]
+  run grep -q "^name: caveman" "$dst"
+  [ "$status" -eq 0 ]
+}
+
+@test "add_optional_role_to_project caveman appends a team-roster row" {
+  add_optional_role_to_project "caveman"
+  run grep -q "Caveman" "${TARGET_DIR}/docs/team-roster.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "deployed caveman files have no leftover {{PLACEHOLDER}} tokens" {
+  add_optional_role_to_project "caveman"
+  run grep -E '\{\{[A-Z_]+\}\}' \
+    "${TARGET_DIR}/.github/instructions/caveman.instructions.md" \
+    "${TARGET_DIR}/.claude/agents/caveman.md" \
+    "${TARGET_DIR}/.cursor/agents/caveman.md"
+  [ "$status" -ne 0 ]
+}
+
+# ── Opt-in behaviour ─────────────────────────────────────────────────────────
+
+@test "deploy_default_optional_roles does NOT include caveman by default" {
+  # Required globals for the function
+  TECH_STACK="Python"
+  DETECTED_STACK=""
+  DETECTED_HAS_SHELL=false
+  INCLUDE_CAVEMAN=false
+
+  deploy_default_optional_roles
+
+  [ ! -f "${TARGET_DIR}/.github/instructions/caveman.instructions.md" ]
+  [ ! -f "${TARGET_DIR}/.claude/agents/caveman.md" ]
+  [ ! -f "${TARGET_DIR}/.cursor/agents/caveman.md" ]
+}
+
+@test "deploy_default_optional_roles includes caveman when INCLUDE_CAVEMAN=true" {
+  TECH_STACK="Python"
+  DETECTED_STACK=""
+  DETECTED_HAS_SHELL=false
+  INCLUDE_CAVEMAN=true
+
+  deploy_default_optional_roles
+
+  [ -f "${TARGET_DIR}/.github/instructions/caveman.instructions.md" ]
+  [ -f "${TARGET_DIR}/.claude/agents/caveman.md" ]
+  [ -f "${TARGET_DIR}/.cursor/agents/caveman.md" ]
+}

--- a/wizard.sh
+++ b/wizard.sh
@@ -69,6 +69,7 @@ DETECTED_HAS_SHELL=false
 # CLI flags
 DEPLOY_HERE=false        # --here: deploy in current directory using inferred values
 AUTO_CONFIRM=false       # --yes/-y: skip confirmation prompts when used with --here
+INCLUDE_CAVEMAN=false    # --caveman: opt-in token-efficient communication overlay role
 
 # Colores
 RED='\033[0;31m'
@@ -1486,6 +1487,12 @@ deploy_default_optional_roles() {
         add_optional_role_to_project "shell-scripting"
         info "Auto-selected optional role: shell-scripting"
     fi
+
+    # Opt-in caveman overlay (token-efficient communication style).
+    if $INCLUDE_CAVEMAN; then
+        add_optional_role_to_project "caveman"
+        info "Opt-in optional role: caveman (token-efficient communication)"
+    fi
 }
 
 # ─── Deployment orchestrator ───────────────────────────────
@@ -1849,6 +1856,7 @@ show_help() {
     echo "    ./wizard.sh                  Interactive Understudy deployment"
     echo "    ./wizard.sh --here           Deploy in current directory using inferred values"
     echo "    ./wizard.sh --here --yes     Same as --here, skip confirmation prompt"
+    echo "    ./wizard.sh --caveman        Include the caveman role (token-efficient overlay)"
     echo "    ./wizard.sh --add-member     Add a team member"
     echo "    ./wizard.sh --create-role    Create a new custom role"
     echo "    ./wizard.sh --help           Show this help"
@@ -1882,6 +1890,7 @@ main() {
         case "$1" in
             --here)     DEPLOY_HERE=true ;;
             --yes|-y)   AUTO_CONFIRM=true ;;
+            --caveman)  INCLUDE_CAVEMAN=true ;;
             *)          _args+=("$1") ;;
         esac
         shift


### PR DESCRIPTION
## Description

Adds an opt-in **caveman** role to the Understudy team — a behavioural overlay
inspired by [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman)
that makes the active agent respond in token-efficient "caveman speak"
(drop articles and filler, keep technical accuracy intact). Targets ~50–75%
output-token reduction on prose-heavy answers without losing meaning.

This is **Phase 1 of 3** in the v0.6.0 caveman-mode initiative. Hooks,
statusline badges and slash commands are intentionally deferred and tracked
in repo memory for future iterations.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## What changes?

- `roles/caveman.instructions.md` — new role file (Identity, Mission, Expertise,
  How-you-work, Standards, Team interaction). Documents 3 intensity levels
  (`lite` / `full` / `ultra`) and explicit non-compress rules (code blocks,
  paths, URLs, security warnings, ADRs, session log).
- `wizard.sh`:
  - `INCLUDE_CAVEMAN=false` global flag.
  - New CLI flag `--caveman` opts the role in for the deploy.
  - `deploy_default_optional_roles` deploys the role only when
    `INCLUDE_CAVEMAN=true`. Default behaviour for existing users is unchanged.
  - `show_help` documents the new flag.
- `tests/unit/caveman_role.bats` — 12 tests covering: catalog presence,
  identity / motto / intensity hints, deployment to all 3 platforms with
  correct frontmatter, team-roster row insertion, no leftover placeholder
  tokens, and the opt-in contract (NOT auto-deployed by default,
  IS deployed when `INCLUDE_CAVEMAN=true`).

The role uses the existing `add_optional_role_to_project()` machinery, so it
inherits the same Claude `tools` array as other optional roles (decision: caveman
is a behavioural overlay — limiting tools would force users to drop the role
to recover capabilities; no new attack surface).

## How to test

```bash
bash -n wizard.sh && shellcheck wizard.sh
./run_tests.sh        # 188 → 200 tests, all pass
# Manual smoke
mkdir -p /tmp/caveman-demo && cd /tmp/caveman-demo
echo "# demo" > README.md
"$UNDERSTUDY/wizard.sh" --here --yes --caveman
ls .github/instructions/caveman.instructions.md  # exists
ls .claude/agents/caveman.md                      # exists
ls .cursor/agents/caveman.md                      # exists
grep Caveman docs/team-roster.md                  # roster row added
# Without the flag
"$UNDERSTUDY/wizard.sh" --here --yes
ls .github/instructions/caveman.instructions.md   # NOT exists
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (`--help`; full
      docs ship in Phase 3 of this initiative)
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published
