### PR TITLE
docs(caveman): chapter 11, matrix, CHANGELOG [0.6.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-04-29
+
+### Added
+
+- **Caveman mode** — token-efficient AI collaboration, ported from
+  [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman) and
+  adapted to Understudy's multi-platform model. Two surfaces:
+  - **Optional `caveman` role** (`roles/caveman.instructions.md`) deployed
+    to Copilot, Claude Code and Cursor. Opt-in via `./wizard.sh --caveman`
+    or `./wizard.sh --add-member caveman`. Three intensity levels: lite,
+    full (default), ultra. Preserves code, paths, URLs, GUARDRAILS markers,
+    ADRs and `docs/decisions.md` byte-identically.
+  - **`scripts/understudy-compress`** — Python 3.8+ Markdown compressor.
+    Stdlib only by default; optional `tiktoken` for exact token counts via
+    interactive prompt or `--yes`. `--dry-run` and `--restore` supported.
+    Backup at `<file>.original.md`. Hard safety gates: refuses symlinks,
+    files outside CWD, sensitive filenames (`.env`, `*secret*`,
+    `*credential*`, `*private_key*`, `id_rsa`, `*.pem`, `*.key`, `*.p12`,
+    `*.pfx`) and sensitive content (PEM blocks, AWS keys, GitHub PATs,
+    JWTs, Slack tokens, `password=`, `api_key=`).
+  - **`scripts/requirements.txt`** declaring optional `tiktoken` dep.
+  - 12 new bats tests for the role (`tests/unit/caveman_role.bats`) and
+    20 for the compress script (`tests/unit/compress.bats`).
+
+### Documentation
+
+- New chapter [Caveman Mode](docs/11-caveman-mode.md) with platform support
+  matrix, intensity levels, safety gates, deferred-features rationale and
+  honest disclaimer about output-only token effects.
+- Platform comparison matrix updated with two new rows (caveman role,
+  compress script) — supported on all four platforms.
+- Docs index updated to link chapter 11.
+
+### Notes
+
+- Hooks, statuslines, slash commands and the wenyan post-processor from
+  upstream are intentionally **not** ported. Rationale and revisit
+  conditions documented in chapter 11 and in repository memory.
+
 ## [0.5.5] - 2026-04-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -400,7 +400,8 @@ The `roles/` folder is the **official optional roles catalog** for the system. T
 
 | Role | When to use it |
 |---|---|
-| 📊 **data-engineer** | ETL/ELT pipelines, data warehouses, streaming, data governance |
+| � **caveman** | Token-efficient prose. Drops fillers; keeps code/paths/URLs. Opt-in via `--caveman`. See [Caveman Mode](docs/11-caveman-mode.md). |
+| �📊 **data-engineer** | ETL/ELT pipelines, data warehouses, streaming, data governance |
 | 🌿 **git-specialist** | Git workflows, branch policies, PR hygiene, release discipline |
 | 📱 **mobile-engineer** | iOS/Android apps, React Native, Flutter |
 | 🤖 **ml-engineer** | ML models, MLOps, LLMs, RAG, responsible AI |

--- a/docs/03-platform-comparison.md
+++ b/docs/03-platform-comparison.md
@@ -17,6 +17,8 @@ Understudy (`understudy`, or `./wizard.sh` if you are using a manual clone).
 | Persistent cross-session memory | ✅ via `docs/*.md` | ✅ via `docs/*.md` | ✅ via `docs/*.md` | ✅ via `docs/*.md` |
 | Existing project integration | ✅ | ✅ | ✅ | ✅ |
 | Monorepo stack detection | ✅ | ✅ | ✅ | ✅ |
+| Caveman mode (token-efficient role) | ✅ opt-in | ✅ opt-in | ✅ opt-in | ✅ opt-in |
+| Caveman compress script | ✅ repo-level (Python) | ✅ repo-level (Python) | ✅ repo-level (Python) | ✅ repo-level (Python) |
 
 Legend: ✅ supported, ⚠️ partial/manual, ❌ not available.
 

--- a/docs/11-caveman-mode.md
+++ b/docs/11-caveman-mode.md
@@ -1,0 +1,206 @@
+# 11. Caveman Mode
+
+> *"Why use many token when few token do trick."* — `roles/caveman.instructions.md`
+
+Caveman mode is Understudy's take on token-efficient AI collaboration, inspired
+by [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman). It has
+two complementary surfaces:
+
+1. **The `caveman` role** — an opt-in team member that *makes agents speak*
+   in a token-efficient style without losing technical accuracy.
+2. **The `understudy-compress` script** — *makes the prose Understudy generates
+   smaller* so every session loads fewer tokens before the agent says a word.
+
+Both ship in v0.6.0. Hooks, statuslines, slash commands and the wenyan
+post-processor from upstream are intentionally **not** ported — see
+[Not shipped](#not-shipped) below.
+
+---
+
+## 1. The `caveman` role
+
+`roles/caveman.instructions.md` is an optional role with the same shape as
+`git-specialist` and `repo-documenter`. It instructs the model to:
+
+- Drop articles, fillers, and hedging phrases.
+- Preserve code blocks, paths, URLs, commands, version numbers and dates
+  byte-for-byte.
+- **Never** compress security warnings, `<!-- GUARDRAILS_START -->` blocks,
+  ADRs, `docs/decisions.md`, or session logs.
+
+Three intensity hints you can ask for inline:
+
+| Intensity | Behavior |
+| --- | --- |
+| `lite`  | Trim filler and articles, keep full sentences. |
+| `full`  | Telegraphic prose. Default. |
+| `ultra` | Bullets only, no prose. Use sparingly — tradeoffs accuracy. |
+
+### Enable it
+
+```bash
+# When deploying:
+./wizard.sh --caveman                # convenience flag
+# or, after deploy:
+./wizard.sh --add-member caveman
+```
+
+It is **opt-in only** (unlike `git-specialist`, which auto-deploys). It does
+not change the behavior of other team members; you address `caveman` directly
+when you want condensed answers.
+
+### Platform support
+
+| Platform | Role file location | Active? |
+| --- | --- | :---: |
+| GitHub Copilot CLI | `.github/instructions/caveman.instructions.md` | ✅ |
+| VS Code Copilot | `.github/instructions/caveman.instructions.md` | ✅ |
+| Claude Code | `.claude/agents/caveman.md` (frontmatter `name`, `description`, `model`, `tools`) | ✅ |
+| Cursor | `.cursor/agents/caveman.md` | ✅ |
+
+The role works identically on every platform Understudy supports.
+
+---
+
+## 2. The `understudy-compress` script
+
+`scripts/understudy-compress` rewrites a Markdown file in place, removing
+filler words and high-frequency low-information phrases while preserving:
+
+- Fenced code blocks (` ``` ` and `~~~`)
+- YAML frontmatter
+- Inline `code` spans
+- URLs, file paths, version numbers and ISO dates
+- Markdown links and images
+- Template tokens like `{{PROJECT_NAME}}`
+- Understudy GUARDRAILS markers and `<!-- new members here -->` anchors
+- Headings, horizontal rules, tables, HTML comments
+- Original line indentation
+
+### Implementation
+
+The script is **Python ≥ 3.8, stdlib-only by default**. We chose Python over
+bash because the bash prototype was unreasonably slow on Git Bash mingw and
+brittle around `sed` portability (BSD vs GNU vs mingw stripping control bytes).
+Python `re` is one regex engine, portable across CI runners and developer
+machines.
+
+> **Note for Windows users**: install Python 3 via
+> `scoop install python`, `winget install Python.Python.3.13`, or the
+> [official installer](https://www.python.org/downloads/). macOS and modern
+> Linux distros ship Python 3.
+
+### Usage
+
+```bash
+# Compress a doc (creates <file>.original.md backup, modifies in place)
+./scripts/understudy-compress docs/team-roster.md
+
+# Preview without writing
+./scripts/understudy-compress --dry-run docs/team-roster.md
+
+# Restore from backup (deletes the .original.md)
+./scripts/understudy-compress --restore docs/team-roster.md
+
+# Non-interactive (CI): never prompt
+./scripts/understudy-compress --no-install --yes docs/team-roster.md
+```
+
+### Optional dependency: `tiktoken`
+
+For exact OpenAI/Anthropic-compatible token counts (using the `cl100k_base`
+encoding), install `tiktoken`. The script will offer to install it on first
+run; you can also do it manually:
+
+```bash
+pip install --user tiktoken
+# or
+pip install --user -r scripts/requirements.txt
+```
+
+Without `tiktoken`, the script falls back to whitespace-delimited word count.
+This is the only optional dependency. Use `--no-install` to skip the prompt
+in any environment.
+
+> **PEP 668 environments** (Debian/Ubuntu 23.04+, recent Fedora): `pip install
+> --user` may be blocked. Use `pipx install tiktoken` or a project venv. The
+> script will print a clear hint if pip refuses.
+
+### Safety: things the script refuses
+
+These gates are non-bypassable:
+
+- **Symlinks** — refused outright. Operate on real files only.
+- **Files outside the current working directory** — including absolute paths
+  that resolve outside CWD.
+- **Sensitive filenames** — `.env*`, `*secret*`, `*credential*`,
+  `*password*`, `*private_key*`, `id_rsa*`, `*.pem`, `*.key`, `*.p12`, `*.pfx`.
+- **Sensitive content** — files containing PEM private-key blocks, AWS access
+  key IDs (`AKIA...`), GitHub PATs (`ghp_...`), Slack tokens (`xox[abprs]-`),
+  JWTs, `password=...`, `api_key=...`.
+
+When refused, the script exits with code `2` and prints which rule matched.
+
+### What the script preserves vs. compresses
+
+It **never modifies** these regions:
+
+- Inside fenced code blocks
+- Inside YAML frontmatter
+- Inline `` `code` `` spans, URLs, Markdown links, paths, versions, ISO dates,
+  template tokens
+- Headings, horizontal rules, table rows, full-line HTML comments
+- Lines containing GUARDRAILS markers or `new members here`
+
+It **does compress** prose lines outside the above by removing 13 high-frequency
+phrases and 14 filler words (e.g. "in order to" → "to", "it is important to
+note that the" → "the", "just", "simply", "really", articles where unambiguous).
+The compressor runs idempotently — applying its substitutions until no further
+change occurs (max 8 iterations).
+
+### Round-trip guarantee
+
+Every successful compression writes `<file>.original.md` (byte-identical to
+the input). `--restore` restores from that backup byte-identically and
+removes the backup. The unit test suite (`tests/unit/compress.bats`)
+asserts byte-identical round-trip.
+
+---
+
+## Not shipped
+
+The upstream caveman repo includes features Understudy has chosen **not** to
+port (yet). Each was evaluated and consciously deferred:
+
+| Feature | Status | Why deferred |
+| --- | --- | --- |
+| Pre/post-prompt **hooks** | Deferred | Platform-specific; Claude Code is the only first-class target. Will land as `--with-hooks` in a future minor release. |
+| **Statusline** | Deferred | Claude-only. Limited cross-platform value. |
+| **Slash commands** for compression | Deferred | Each platform has its own command grammar; needs a separate design. |
+| **wenyan** (Classical Chinese post-processor) | Skipped | Out of scope for an English-language ops tool. |
+| **Token evaluation harness** | Deferred | Belongs in a `tests/evals/` folder with `tiktoken` and a 3-arm methodology (no-caveman vs. caveman role vs. compress + role). |
+
+The full deferred-features rationale and revisit conditions are tracked in
+`/memories/repo/caveman-deferred-features.md` (workspace memory).
+
+---
+
+## Honest disclaimer
+
+Caveman mode reduces the **input** tokens an agent reads (via compression) and
+the **output** tokens it writes (via the role). It does **not** make the model
+"reason in fewer tokens"; the same model with the same context produces the
+same answer quality. The win is wall-clock latency, context-window headroom
+and bill size — not capability.
+
+If you measure savings, do it with `tiktoken` on the prompts your team
+actually uses, not on toy fixtures. Word count is a rough proxy.
+
+---
+
+## Related
+
+- Upstream: [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman)
+- [Configuration reference](09-configuration.md) — adding optional roles
+- [Cross-Platform Workflows](08-cross-platform-workflows.md) — using
+  `caveman` alongside other team members

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ restructuring.
 6. [Configuration Reference (`understudy.yaml`)](09-configuration.md)
    - [Local-only mode](09-configuration.md#local-only-mode) — keep AI config out of git
 7. [Troubleshooting and FAQ](10-troubleshooting.md)
+8. [Caveman Mode (token-efficient role + compress script)](11-caveman-mode.md)
 
 ## How to read this
 


### PR DESCRIPTION
## Description

Phase 3 (final) of v0.6.0 caveman-mode rollout. Documentation only — no code changes.

Closes #

---

## Type of change

- [x] 📝 `docs` — documentation only

---

## What changes?

- New `docs/11-caveman-mode.md` (~180 lines) covering both surfaces of the feature:
  - The `caveman` role (Phase 1, already shipped in PR #35) — how to enable, intensity levels, platform support matrix.
  - The `understudy-compress` script (Phase 2, already shipped in PR #36) — implementation notes (why Python over bash), usage, optional `tiktoken` dep with PEP 668 caveat, safety gates, preserve/compress lists, round-trip guarantee.
  - "Not shipped" section documenting the four upstream caveman features deliberately deferred (hooks, statusline, slash commands, wenyan, evals harness) with rationale.
  - Honest disclaimer about output-only token effects (compress reduces input tokens, role reduces output tokens; neither makes the model "reason in fewer tokens").
- `docs/README.md` — index updated with chapter 11 link.
- `docs/03-platform-comparison.md` — capability matrix gains two rows (caveman role and compress script), supported on all four platforms.
- `README.md` — `caveman` added to the optional roles table at the top of the catalog list.
- `CHANGELOG.md` — new `[0.6.0] - 2026-04-29` section consolidating Phase 1 and Phase 2 deliverables, plus the documentation that lands here.

---

## How to test

```bash
# Lint
markdownlint docs/11-caveman-mode.md docs/README.md docs/03-platform-comparison.md README.md CHANGELOG.md

# Sanity-check internal links
grep -rn "11-caveman-mode" docs/ README.md
```

CI runs Markdown lint on every changed `.md`. No code changes, so bats and shellcheck jobs will pass through unchanged.

---

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] `CHANGELOG.md` updated in the `[0.6.0]` section
- [x] `bash -n wizard.sh` passes without errors _(no shell changes)_
- [x] ShellCheck passes locally _(no shell changes)_
- [x] Affected documentation is updated _(this PR is the documentation)_
- [x] If it's a new role: follows the structure of `roles/data-engineer.instructions.md` _(N/A — docs only)_

Phase 3 of 3 for v0.6.0 caveman-mode. After merge, tag v0.6.0.
