### PR TITLE
fix(release): include scripts/ in release tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,7 @@ jobs:
             understudy.yaml \
             templates \
             roles \
+            scripts \
             docs \
             README.md \
             CHANGELOG.md \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-04-29
+
+### Fixed
+
+- Release tarball was missing `scripts/` (the `understudy-compress` Python
+  script and `requirements.txt` shipped in v0.6.0). The release workflow's
+  explicit file list did not include `scripts/`, so users installing v0.6.0
+  via the published tarball received the caveman role but not the compress
+  script. v0.6.1 adds `scripts/` to the tarball and makes
+  `scripts/understudy-compress` executable on install. Users on v0.6.0
+  should re-run the installer one-liner to get the script.
+
 ## [0.6.0] - 2026-04-29
 
 ### Added

--- a/install.sh
+++ b/install.sh
@@ -149,6 +149,9 @@ download_and_install() {
   mkdir -p "$INSTALL_DIR"
   tar -xzf "${tmp_dir}/${archive}" -C "$INSTALL_DIR" --strip-components=0
   chmod +x "${INSTALL_DIR}/wizard.sh"
+  # Optional: scripts directory only present from v0.6.0 onwards.
+  [[ -f "${INSTALL_DIR}/scripts/understudy-compress" ]] && \
+    chmod +x "${INSTALL_DIR}/scripts/understudy-compress"
   rm -rf "$tmp_dir"
 
   success "Files installed to ${INSTALL_DIR}"


### PR DESCRIPTION
## Description

Hotfix for v0.6.0. The release workflow's explicit `tar` file list did not include `scripts/`, so the published tarball at `v0.6.0` shipped without `scripts/understudy-compress` and `scripts/requirements.txt`. Users installing v0.6.0 via the one-liner received the `caveman` role but not the compress script.

This is the same class of issue as the v0.5.3 fix (`templates/.github/` being stripped by `--exclude='.github'`).

Closes #

---

## Type of change

- [x] 🐛 `fix` — bug fix
- [x] ⚙️ `ci` — CI/CD changes

---

## What changes?

- `.github/workflows/release.yml` — adds `scripts` to the explicit file list passed to `tar -czf`. No other changes to the release pipeline.
- `install.sh` — `chmod +x scripts/understudy-compress` after extraction (guarded by file existence so it remains compatible with pre-v0.6.0 tarballs).
- `CHANGELOG.md` — new `[0.6.1] - 2026-04-29` section.

---

## How to test

```bash
# Verify the bug exists in v0.6.0
curl -fsSL https://github.com/erniker/understudy/releases/download/v0.6.0/understudy-v0.6.0.tar.gz \
  | tar tz | grep -E "scripts/" || echo "BUG CONFIRMED: no scripts/ in v0.6.0 tarball"

# After this PR is merged and v0.6.1 tagged:
curl -fsSL https://github.com/erniker/understudy/releases/download/v0.6.1/understudy-v0.6.1.tar.gz \
  | tar tz | grep -E "scripts/(understudy-compress|requirements.txt)"
# Expect both files listed.
```

---

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] `CHANGELOG.md` updated in the `[0.6.1]` section
- [x] `bash -n wizard.sh` passes without errors _(no wizard changes)_
- [x] ShellCheck passes locally
- [x] Affected documentation is updated _(no doc changes needed; chapter 11 already documents the script)_
- [x] If it's a new role: follows the structure of `roles/data-engineer.instructions.md` _(N/A)_
