### PR TITLE
docs: credit JuliusBrussee/caveman as inspiration for caveman mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Documentation
+
+- Added an `Acknowledgments` section to `README.md` thanking
+  [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman) for
+  inspiring caveman mode, and reinforced the upstream credit in the chapter
+  intro of [docs/11-caveman-mode.md](docs/11-caveman-mode.md).
+
 ## [0.6.1] - 2026-04-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -528,3 +528,12 @@ To report bugs or propose improvements use the [issue templates](https://github.
 To report security vulnerabilities, see the [security policy](SECURITY.md).
 
 This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md) as its code of conduct.
+
+## Acknowledgments
+
+- **Caveman mode** (the `caveman` role and the `understudy-compress` script)
+  is inspired by [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman) —
+  thanks to its author for the original idea of token-efficient AI prose and for
+  open-sourcing the prompt patterns that informed our port. See
+  [docs/11-caveman-mode.md](docs/11-caveman-mode.md) for what we adapted and
+  what we intentionally did not ship.

--- a/docs/11-caveman-mode.md
+++ b/docs/11-caveman-mode.md
@@ -3,7 +3,8 @@
 > *"Why use many token when few token do trick."* — `roles/caveman.instructions.md`
 
 Caveman mode is Understudy's take on token-efficient AI collaboration, inspired
-by [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman). It has
+by [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman) — thanks
+to its author for open-sourcing the original idea and prompt patterns. It has
 two complementary surfaces:
 
 1. **The `caveman` role** — an opt-in team member that *makes agents speak*


### PR DESCRIPTION
## Description

Adds an explicit acknowledgment of the upstream project that inspired caveman mode in v0.6.0.

The role file (`roles/caveman.instructions.md`) and CHANGELOG [0.6.0] already linked upstream; this PR makes the gratitude visible from the README front door.

## Type of change

- [x] Documentation update

## What changes?

- `README.md`: new `Acknowledgments` section linking to https://github.com/JuliusBrussee/caveman.
- `docs/11-caveman-mode.md`: reinforced upstream credit in the chapter intro.
- `CHANGELOG.md`: entry under `[Unreleased]` -> Documentation.

## How to test

- Open `README.md` and verify the `Acknowledgments` section appears at the bottom and links to JuliusBrussee/caveman.
- Open `docs/11-caveman-mode.md` and verify the chapter intro thanks the upstream author.
- `./run_tests.sh` (no behavioural changes; should remain green).

## Checklist

- [x] Conventional Commits
- [x] CHANGELOG.md updated
- [x] No code changes (docs-only)
