### PR TITLE
chore: detect missing python3 in run_tests.sh with a clear notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Changed
+
+- `run_tests.sh`: prints an informational notice if `python3` is missing
+  and exports `UNDERSTUDY_NO_PYTHON=1` so any future Python-dependent
+  test can gate on it cleanly instead of failing with an opaque "command
+  not found". Documented in `CONTRIBUTING.md` §8.
+
 ## [0.7.0] - 2026-04-29
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -350,6 +350,21 @@ npm install -g bats
 bats tests/unit/config_read.bats
 ```
 
+### Optional: python3
+
+`run_tests.sh` is pure Bash and does **not** require `python3`. The runner
+prints a friendly notice if `python3` is missing and exports
+`UNDERSTUDY_NO_PYTHON=1` so any future test that depends on Python can
+gate on it cleanly:
+
+```bash
+# inside a future python-dependent .bats file
+[[ -n "${UNDERSTUDY_NO_PYTHON:-}" ]] && skip "python3 not available"
+```
+
+The opt-in `tests/evals/` harness has its own Python requirement and is
+not driven by `run_tests.sh` — see the section below.
+
 ### Test layout
 
 ```

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -32,6 +32,16 @@ if ! command -v bats &>/dev/null; then
   exit 1
 fi
 
+# Optional: python3 is not required by the bash test suite, but some
+# opt-in tooling under tests/evals/ uses it. Warn early so any future
+# test that depends on python3 can gate cleanly on this variable
+# instead of failing with an opaque "command not found".
+if ! command -v python3 &>/dev/null; then
+  echo -e "${CYAN}ℹ${NC}  python3 not found; tests that require it will be skipped."
+  echo ""
+  export UNDERSTUDY_NO_PYTHON=1
+fi
+
 echo ""
 echo -e "  ${BOLD}🎭 Understudy Test Suite${NC}"
 echo -e "  bats $(bats --version 2>/dev/null | head -1)"


### PR DESCRIPTION
## Description

Closes #52. `run_tests.sh` is pure Bash today, but the opt-in `tests/evals/` harness uses Python and any future Python-dependent test would otherwise fail with an opaque `command not found`. Add a friendly early check.

## Type of change

- [x] Chore / DX improvement

## What changes?

- `run_tests.sh`: prints an informational notice if `python3` is missing and exports `UNDERSTUDY_NO_PYTHON=1` so future Python-dependent `.bats` files can gate on it cleanly.
- `CONTRIBUTING.md` §8: new "Optional: python3" subsection that documents the variable and the gating idiom for future test files.
- `CHANGELOG.md`: entry under `[Unreleased] -> Changed`.

## How to test

- `./run_tests.sh` on a host with `python3` present: same output as before, all 141 unit + integration tests pass.
- `./run_tests.sh` on a host without `python3`: prints `python3 not found; tests that require it will be skipped.` and continues, all tests still pass.
- Locally validated on Windows + Git Bash with python3 present (status quo) — all suites green.

## Checklist

- [x] Conventional Commits
- [x] CHANGELOG.md updated
- [x] No behavioural change to existing tests
- [x] No new tests required (gate variable is for future use)
