### PR TITLE
docs: adopt Breaking Changes convention and validate CHANGELOG date

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,35 @@ jobs:
           # Write to file to preserve newlines
           echo "$notes" > release_notes.md
 
+      - name: Validate CHANGELOG date matches release date
+        run: |
+          version="${{ steps.version.outputs.version }}"
+          semver="${version#v}"
+
+          # Pull "YYYY-MM-DD" from "## [X.Y.Z] - YYYY-MM-DD"
+          declared=$(grep -E "^## \[${semver}\] - [0-9]{4}-[0-9]{2}-[0-9]{2}" CHANGELOG.md \
+            | head -n1 \
+            | sed -E 's/.*- ([0-9]{4}-[0-9]{2}-[0-9]{2}).*/\1/')
+
+          if [[ -z "$declared" ]]; then
+            echo "::error::CHANGELOG entry for ${version} is missing a date in '## [${semver}] - YYYY-MM-DD' format."
+            exit 1
+          fi
+
+          today=$(date -u +%Y-%m-%d)
+          yesterday=$(date -u -d "yesterday" +%Y-%m-%d)
+          tomorrow=$(date -u -d "tomorrow" +%Y-%m-%d)
+
+          # Allow +/- 1 day for timezone slop between the tagger's local
+          # clock and the runner's UTC clock. Anything beyond that is
+          # almost certainly a forgotten CHANGELOG bump.
+          if [[ "$declared" != "$today" && "$declared" != "$yesterday" && "$declared" != "$tomorrow" ]]; then
+            echo "::error::CHANGELOG date for ${version} is ${declared} but the release ran on ${today} (UTC). Update '## [${semver}] - ...' before re-tagging."
+            exit 1
+          fi
+
+          echo "CHANGELOG date ${declared} is within +/- 1 day of release date ${today} (UTC). OK."
+
       - name: Build release tarball
         run: |
           version="${{ steps.version.outputs.version }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,17 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   Uses the word-count fallback (no `tiktoken` install) so the job stays
   fast. The companion issue #43 covers regenerating `RESULTS.md` with
   real `tiktoken` numbers.
+- **Release date guard**: `.github/workflows/release.yml` now validates
+  that the date in `## [X.Y.Z] - YYYY-MM-DD` is within ±1 day (UTC) of
+  the release run, so a forgotten CHANGELOG date bump fails the workflow
+  instead of shipping silently with the wrong date.
 
 ### Changed
 
+- `CONTRIBUTING.md` §6: documents the `### Breaking Changes` subsection
+  in the `[Unreleased]` block and ties it to the `feat!:` /
+  `BREAKING CHANGE:` footer convention from §4. Listed first in each
+  release block so downstream consumers see breakage before additions.
 - `run_tests.sh`: prints an informational notice if `python3` is missing
   and exports `UNDERSTUDY_NO_PYTHON=1` so any future Python-dependent
   test can gate on it cleanly instead of failing with an opaque "command

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,8 +190,11 @@ git push upstream v0.2.0
 After the push, CI will:
 
 1. Extract the `[X.Y.Z]` section from `CHANGELOG.md` as release notes.
-2. Build `understudy-vX.Y.Z.tar.gz` (wizard, templates, roles, docs — no test files).
-3. Publish the GitHub Release with the tarball attached.
+2. Validate that the date in `## [X.Y.Z] - YYYY-MM-DD` is within ±1 day
+   (UTC) of the release run. The workflow fails otherwise — bump the
+   date before re-tagging.
+3. Build `understudy-vX.Y.Z.tar.gz` (wizard, templates, roles, docs — no test files).
+4. Publish the GitHub Release with the tarball attached.
 
 ### What goes in the release tarball
 
@@ -222,6 +225,9 @@ After the push, CI will:
 ```markdown
 ## [Unreleased]
 
+### Breaking Changes
+- Description of a backward-incompatible change. Always listed first.
+
 ### Added
 - Description of new functionality.
 
@@ -240,6 +246,14 @@ After the push, CI will:
 ### Security
 - Fixed vulnerability.
 ```
+
+> **Breaking Changes convention.** Any commit landed with `feat!:` /
+> `fix!:` / `BREAKING CHANGE:` footer (see §4) MUST add a bullet under
+> `### Breaking Changes` in `[Unreleased]`. The subsection is listed
+> **before** `### Added` so downstream consumers see breakage first.
+> While the project is at `0.x.y`, breaking changes are still allowed in
+> a MINOR bump (pre-1.0 SemVer), but they must still be marked.
+
 
 ### Rules
 


### PR DESCRIPTION
## Description

Closes #54 and #50 — two small, independent guard-rails for the release process. Bundled in one PR because both are pure docs / CI-config and neither touches runtime code.

## Type of change

- [x] Documentation
- [x] CI / tooling

## What changes?

### #54 — Breaking Changes convention

- `CONTRIBUTING.md` §6: documents a `### Breaking Changes` subsection at the top of every release block in `CHANGELOG.md`, listed **before** `### Added`. Ties it to the existing `feat!:` / `BREAKING CHANGE:` footer convention already documented in §4.
- No CI lint yet — deferred until v1.0 prep, per the issue.
- No backfill needed: 0.x SemVer tolerates breaking changes in MINOR bumps and none of the previous releases were marked breaking.

### #50 — Validate CHANGELOG date matches release tag

- `.github/workflows/release.yml`: new "Validate CHANGELOG date matches release date" step between the existing changelog-extraction step and the tarball build.
- Extracts the date from `## [X.Y.Z] - YYYY-MM-DD` and compares it against the runner's UTC date with a ±1 day tolerance (covers the case where the tagger pushes near midnight in a non-UTC timezone).
- Fails the workflow with `::error::` if the date is missing or off by more than a day, so a forgotten `[Unreleased] → [X.Y.Z] - YYYY-MM-DD` bump can't ship silently.
- Documented in `CONTRIBUTING.md` §5 as part of what CI does after a tag push.

## How to test

- The release workflow only runs on `v*.*.*` tag pushes, so this PR cannot exercise it directly. The shell snippet was sanity-checked locally:
  - `grep -E "^## \[0\.7\.0\] - [0-9]{4}-[0-9]{2}-[0-9]{2}" CHANGELOG.md | head -n1 | sed -E 's/.*- ([0-9]{4}-[0-9]{2}-[0-9]{2}).*/\1/'` → `2026-04-29` ✓
- Existing CI checks (bats, shellcheck, markdown lint, etc.) run on this PR and must stay green.

## Checklist

- [x] Conventional Commits (`docs:`)
- [x] CHANGELOG.md updated under `[Unreleased] → Added`
- [x] No new bats tests required (workflow-only / docs-only)
- [x] No breaking changes
