### PR TITLE
ci: soften PR template check and document gh pr edit retrigger gotcha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,28 +26,45 @@ jobs:
             exit 1
           fi
 
-          required_sections=(
-            '## Description'
-            '## Type of change'
-            '## What changes?'
-            '## How to test'
-            '## Checklist'
+          # Required section headings. Matched case-insensitively and we
+          # allow trailing punctuation/emojis (e.g. "## Description :"),
+          # so a typo like an extra ':' or a translated emoji does not
+          # silently fail the gate. The leading '## ' prefix is still
+          # mandatory so contributors keep using H2 sections.
+          required_patterns=(
+            '^##[[:space:]]+description([[:space:]]|[^[:alnum:]]|$)'
+            '^##[[:space:]]+type[[:space:]]+of[[:space:]]+change([[:space:]]|[^[:alnum:]]|$)'
+            '^##[[:space:]]+what[[:space:]]+changes\??([[:space:]]|[^[:alnum:]]|$)'
+            '^##[[:space:]]+how[[:space:]]+to[[:space:]]+test([[:space:]]|[^[:alnum:]]|$)'
+            '^##[[:space:]]+checklist([[:space:]]|[^[:alnum:]]|$)'
+          )
+          missing_labels=(
+            'Description'
+            'Type of change'
+            'What changes?'
+            'How to test'
+            'Checklist'
           )
 
-          for section in "${required_sections[@]}"; do
-            if ! printf '%s\n' "$PR_BODY" | grep -Fq "$section"; then
-              echo "Missing required PR template section: $section"
+          for i in "${!required_patterns[@]}"; do
+            if ! printf '%s\n' "$PR_BODY" | grep -Eiq "${required_patterns[$i]}"; then
+              echo "Missing required PR template section: ## ${missing_labels[$i]}"
               exit 1
             fi
           done
 
+          # Capture the body of the "Type of change" section (until the
+          # next H2 or a horizontal rule). Lower-cased inside awk so the
+          # heading match is case-insensitive on both gawk and mawk.
           type_section=$(printf '%s\n' "$PR_BODY" | awk '
-            /^## Type of change$/ { capture=1; next }
-            /^---$/ && capture { exit }
+            { lc = tolower($0) }
+            lc ~ /^##[[:space:]]+type[[:space:]]+of[[:space:]]+change/ { capture=1; next }
+            capture && lc ~ /^##[[:space:]]/ { exit }
+            capture && /^---$/ { exit }
             capture { print }
           ')
 
-          if ! printf '%s\n' "$type_section" | grep -Eq '^- \[(x|X)\] '; then
+          if ! printf '%s\n' "$type_section" | grep -Eq '^[[:space:]]*-[[:space:]]*\[(x|X)\][[:space:]]+'; then
             echo "Select at least one item in the 'Type of change' section."
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- **PR template check is now lenient**: the `Pull request template`
+  job in `.github/workflows/ci.yml` matches required H2 sections
+  case-insensitively and tolerates trailing punctuation or emojis
+  (e.g. `## How to Test 🧪`). Minor formatting differences no longer
+  silently fail the gate. Documented in `CONTRIBUTING.md` §7, along
+  with the `gh pr edit` retrigger gotcha (close+reopen the PR or push
+  a new commit).
 - `CONTRIBUTING.md` §6: documents the `### Breaking Changes` subsection
   in the `[Unreleased]` block and ties it to the `feat!:` /
   `BREAKING CHANGE:` footer convention from §4. Listed first in each

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -318,6 +318,30 @@ After the push, CI will:
 - Reference the related issue with `Closes #NNN` or `Fixes #NNN`.
 - If the PR is a **draft**, explicitly mark it as Draft.
 
+### PR template check
+
+The required check **"Pull request template"** validates that the PR
+body keeps the H2 sections from `.github/PULL_REQUEST_TEMPLATE.md`
+(`## Description`, `## Type of change`, `## What changes?`,
+`## How to test`, `## Checklist`) and that at least one box under
+`## Type of change` is checked. The match is case-insensitive and
+tolerates trailing punctuation or emojis (e.g. `## How to Test 🧪`),
+so minor formatting differences do not break the gate.
+
+> **Gotcha — `gh pr edit` does not retrigger workflows.**
+> If the check fails because of a body issue, fixing the body with
+> `gh pr edit --body-file` will update the PR text but will **not**
+> rerun the "Pull request template" job. To retrigger it, close and
+> reopen the PR:
+>
+> ```bash
+> gh pr close <NUMBER>
+> gh pr reopen <NUMBER>
+> ```
+>
+> Pushing a new commit also retriggers all checks and is the cleanest
+> option when you also need to amend the diff.
+
 ### Review
 
 - At least **1 approval** from a maintainer to merge.


### PR DESCRIPTION
## Description

Closes #51. Two papercuts in the required `Pull request template` check:

1. The check matched required H2 sections by exact literal — a typo, an emoji or a slight punctuation drift silently failed the gate.
2. The workaround was undiscoverable: editing the body via `gh pr edit --body-file` does not retrigger the workflow (we hit this during PR #39).

This PR softens the check and documents the retrigger gotcha. The required behaviour is unchanged: the H2 sections must still be present and at least one box under `## Type of change` must still be checked.

## Type of change

- [x] CI / tooling
- [x] Documentation

## What changes?

### `.github/workflows/ci.yml`

- The `pr-template` job now uses **`grep -Eiq`** with extended regex patterns instead of `grep -Fq` against literal strings.
- Patterns require a leading `## ` (still H2) and the section name, but tolerate trailing whitespace, punctuation, emojis, or translated suffixes — e.g. these all pass now: `## Description :` / `## How to Test 🧪` / `## CHECKLIST`.
- The "Type of change" capture uses `awk` with explicit lower-casing (works on both gawk and mawk).
- Empty body and "no type-of-change box checked" still fail with the same clear messages.

### `CONTRIBUTING.md` §7

- New "PR template check" subsection summarising what the gate enforces and what it tolerates.
- New "Gotcha" callout documenting that `gh pr edit` does **not** retrigger workflows, with the `gh pr close N && gh pr reopen N` workaround (or just push a new commit).

### `CHANGELOG.md`

- Entry under `[Unreleased] -> Changed`.

## How to test

- This PR exercises the new check on itself: the body uses the standard sections so it should pass.
- Logic was sanity-checked locally with four fixtures:
  - Clean body matching the template → **PASS**
  - Body with emoji, colon, and `## CHECKLIST` (uppercase) → **PASS**
  - Body missing `## What changes?` → **FAIL** with `Missing required PR template section: ## What changes?`
  - Body with `## Type of change` present but no `[x]` → **FAIL** with `Select at least one item in the 'Type of change' section.`

## Checklist

- [x] Conventional Commits (`ci:`)
- [x] CHANGELOG.md updated under `[Unreleased] -> Changed`
- [x] No new bats tests required (workflow + docs only)
- [x] No breaking changes — bodies that passed before still pass
