### PR TITLE
docs(caveman): link Not-shipped table to roadmap issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- **Caveman roadmap is now discoverable**: the Deferred items in
+  `docs/11-caveman-mode.md` § Not shipped are tracked as labelled
+  (`caveman`) issues — hooks (#59), statusline (#60), and slash
+  commands (#61) — and the table in the doc links to each one.
 - **PR template check is now lenient**: the `Pull request template`
   job in `.github/workflows/ci.yml` matches required H2 sections
   case-insensitively and tolerates trailing punctuation or emojis

--- a/docs/11-caveman-mode.md
+++ b/docs/11-caveman-mode.md
@@ -175,15 +175,15 @@ port (yet). Each was evaluated and consciously deferred:
 
 | Feature | Status | Why deferred |
 | --- | --- | --- |
-| Pre/post-prompt **hooks** | Deferred | Platform-specific; Claude Code is the only first-class target. Will land as `--with-hooks` in a future minor release. |
-| **Statusline** | Deferred | Claude-only. Limited cross-platform value. |
-| **Slash commands** for compression | Deferred | Each platform has its own command grammar; needs a separate design. |
+| Pre/post-prompt **hooks** | Deferred ([#59](https://github.com/erniker/understudy/issues/59)) | Platform-specific; Claude Code is the only first-class target. Will land as `--with-hooks` in a future minor release. |
+| **Statusline** | Deferred ([#60](https://github.com/erniker/understudy/issues/60)) | Claude-only. Limited cross-platform value. |
+| **Slash commands** for compression | Deferred ([#61](https://github.com/erniker/understudy/issues/61)) | Each platform has its own command grammar; needs a separate design. |
 | **wenyan** (Classical Chinese post-processor) | Skipped | Out of scope for an English-language ops tool. |
 | **Token evaluation harness** | **Shipped** in [`tests/evals/`](../tests/evals/README.md) | Dogfood + 3-arm methodology (no-caveman / role / role+compress). Opt-in; not wired into `run_tests.sh`. |
 
-The full deferred-features rationale and revisit conditions for the items
-still marked **Deferred** above are tracked in repository memory; open an
-issue if you want one promoted to a roadmap milestone.
+The deferred items above are tracked as labelled (`caveman`) issues so
+they are discoverable in the issue tracker. They are open for
+discussion, not committed work.
 
 ---
 


### PR DESCRIPTION
## Description

Closes #49. Promotes the Deferred items in [`docs/11-caveman-mode.md` § Not shipped](../blob/main/docs/11-caveman-mode.md#not-shipped) to labelled (`caveman`) issues so they are discoverable in the issue tracker, and links the doc table to each one.

Three issues opened, all labelled `caveman` + `enhancement`, marked **Open for discussion, not committed work**:

- #59 — caveman: opt-in pre/post-prompt hooks (`--with-hooks`)
- #60 — caveman: port Claude Code statusline that reports compression savings
- #61 — caveman: platform slash commands for compression

The `wenyan` row stays Skipped (out of scope) and the evals harness row stays Shipped — neither becomes an issue.

## Type of change

- [x] Documentation

## What changes?

- New repo label `caveman` (color `#8B4513`, "Caveman mode: roadmap items deferred from the upstream caveman feature set").
- Three new issues (#59, #60, #61), each labelled `caveman` + `enhancement`.
- `docs/11-caveman-mode.md`: each Deferred row in the *Not shipped* table now links to its issue, and the trailing paragraph that asked readers to "open an issue if you want one promoted" is replaced with a one-liner pointing them at the labelled issues.
- `CHANGELOG.md`: entry under `[Unreleased] -> Changed`.

## How to test

- Visit https://github.com/erniker/understudy/labels/caveman after merge — the three issues should be listed.
- The doc table renders correctly on GitHub (markdownlint passes locally).

## Checklist

- [x] Conventional Commits (`docs(caveman):`)
- [x] CHANGELOG.md updated under `[Unreleased] -> Changed`
- [x] No code changes
- [x] No new bats tests required
