### PR TITLE
test(caveman): add integration coverage for opt-in role deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   that the date in `## [X.Y.Z] - YYYY-MM-DD` is within ±1 day (UTC) of
   the release run, so a forgotten CHANGELOG date bump fails the workflow
   instead of shipping silently with the wrong date.
+- **Caveman integration coverage**: `tests/integration/deploy_caveman.bats`
+  runs the full wizard with `--caveman` against Copilot/Claude/Cursor
+  combinations and asserts the role files materialise with correct
+  frontmatter, so a regression that breaks caveman deploy on a single
+  platform is now caught by CI.
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -432,8 +432,10 @@ tests/
 │   └── guardrails_check.bats             # Hook blocks destructive commands (exit 2),
 │                                         # warns on secrets (exit 0), allows safe ops
 └── integration/
-    └── deploy_all_platforms.bats         # Full wizard run: files created, placeholders
-                                          # replaced, integration mode preserves files
+    ├── deploy_all_platforms.bats         # Full wizard run: files created, placeholders
+    │                                     # replaced, integration mode preserves files
+    └── deploy_caveman.bats                # Full wizard run with --caveman: opt-in
+                                          # caveman role deploys to all 3 platforms
 ```
 
 ### Anatomy of a test
@@ -477,7 +479,7 @@ Key conventions:
 | Update checker (`read_local_version`, `version_is_newer`) | `tests/unit/update_check.bats` |
 | Path normalization (`normalize_path`) | `tests/unit/normalize_path.bats` |
 | Git integration / `.gitignore` generation | `tests/unit/deploy_gitignore.bats` |
-| `caveman` role file or wizard wiring | `tests/unit/caveman_role.bats` |
+| `caveman` role file or wizard wiring | `tests/unit/caveman_role.bats` (unit) and `tests/integration/deploy_caveman.bats` (end-to-end wizard run) |
 | `scripts/understudy-compress` (rules, safety gates, restore) | `tests/unit/compress.bats` |
 
 ### Caveman evals harness (opt-in)

--- a/tests/integration/deploy_caveman.bats
+++ b/tests/integration/deploy_caveman.bats
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+# Integration tests for the opt-in caveman role deploy across all platforms.
+#
+# Mirrors the pattern of deploy_all_platforms.bats but adds --caveman to the
+# wizard invocation. The unit tests in tests/unit/caveman_role.bats already
+# exercise add_optional_role_to_project() and the INCLUDE_CAVEMAN gate
+# directly; this file closes the end-to-end gap by running the full wizard
+# pipeline so a regression that breaks caveman deploy on, say, Cursor only
+# surfaces in CI.
+#
+# Tracked by issue #53.
+
+WIZARD="${BATS_TEST_DIRNAME}/../../wizard.sh"
+
+setup() {
+  TEST_TMP="$(mktemp -d)"
+}
+
+teardown() {
+  [[ -n "${TEST_TMP:-}" && -d "$TEST_TMP" ]] && rm -rf "$TEST_TMP"
+}
+
+# Helper: run wizard non-interactively with extra CLI flags.
+# Same answer order as deploy_all_platforms.bats::run_wizard_noninteractive().
+# Arguments: project_name base_dir cli_flags... -- copilot claude cursor
+run_wizard_with_flags() {
+  local project_name="$1"
+  local base_dir="$2"
+  shift 2
+  # Split CLI flags from platform answers via the literal '--' delimiter.
+  local flags=()
+  while [[ "$#" -gt 0 && "$1" != "--" ]]; do
+    flags+=("$1")
+    shift
+  done
+  shift  # drop '--'
+
+  printf '%s\n' \
+    "$project_name" \
+    "$base_dir" \
+    "Test description" \
+    ".NET + React" \
+    "Test PM" \
+    "local" \
+    "1" \
+    "$@" \
+    "N" \
+    "N" \
+    "Y" \
+    "n" \
+    | bash "$WIZARD" "${flags[@]}" 2>/dev/null
+}
+
+# ── Caveman opt-in: all platforms ─────────────────────────────────────────────
+
+@test "wizard --caveman deploys Copilot caveman.instructions.md" {
+  run_wizard_with_flags "myproject" "$TEST_TMP" --caveman -- "Y" "Y" "Y"
+  [ -f "$TEST_TMP/myproject/.github/instructions/caveman.instructions.md" ]
+}
+
+@test "wizard --caveman deploys Claude caveman.md with frontmatter" {
+  run_wizard_with_flags "myproject" "$TEST_TMP" --caveman -- "Y" "Y" "Y"
+  local dst="$TEST_TMP/myproject/.claude/agents/caveman.md"
+  [ -f "$dst" ]
+  grep -q "^name: caveman" "$dst"
+  grep -q "^model:" "$dst"
+  grep -q "^tools:" "$dst"
+}
+
+@test "wizard --caveman deploys Cursor caveman.md with frontmatter" {
+  run_wizard_with_flags "myproject" "$TEST_TMP" --caveman -- "Y" "Y" "Y"
+  local dst="$TEST_TMP/myproject/.cursor/agents/caveman.md"
+  [ -f "$dst" ]
+  grep -q "^name: caveman" "$dst"
+}
+
+@test "wizard --caveman appends Caveman row to docs/team-roster.md" {
+  run_wizard_with_flags "myproject" "$TEST_TMP" --caveman -- "Y" "Y" "Y"
+  grep -q "Caveman" "$TEST_TMP/myproject/docs/team-roster.md"
+}
+
+@test "wizard --caveman: deployed caveman files have no {{PLACEHOLDER}} leftovers" {
+  run_wizard_with_flags "myproject" "$TEST_TMP" --caveman -- "Y" "Y" "Y"
+  run grep -E '\{\{[A-Z_]+\}\}' \
+    "$TEST_TMP/myproject/.github/instructions/caveman.instructions.md" \
+    "$TEST_TMP/myproject/.claude/agents/caveman.md" \
+    "$TEST_TMP/myproject/.cursor/agents/caveman.md"
+  [ "$status" -ne 0 ]
+}
+
+# ── Caveman opt-in: per-platform isolation ────────────────────────────────────
+
+@test "wizard --caveman with Claude only deploys only the Claude caveman file" {
+  run_wizard_with_flags "claudeonly" "$TEST_TMP" --caveman -- "n" "Y" "n"
+  [ -f "$TEST_TMP/claudeonly/.claude/agents/caveman.md" ]
+  [ ! -f "$TEST_TMP/claudeonly/.github/instructions/caveman.instructions.md" ]
+  [ ! -f "$TEST_TMP/claudeonly/.cursor/agents/caveman.md" ]
+}
+
+@test "wizard --caveman with Cursor only deploys only the Cursor caveman file" {
+  run_wizard_with_flags "cursoronly" "$TEST_TMP" --caveman -- "n" "n" "Y"
+  [ -f "$TEST_TMP/cursoronly/.cursor/agents/caveman.md" ]
+  [ ! -f "$TEST_TMP/cursoronly/.claude/agents/caveman.md" ]
+  [ ! -f "$TEST_TMP/cursoronly/.github/instructions/caveman.instructions.md" ]
+}
+
+# ── Default (no --caveman): role must NOT be deployed ────────────────────────
+
+@test "wizard without --caveman does NOT deploy any caveman files" {
+  run_wizard_with_flags "default" "$TEST_TMP" -- "Y" "Y" "Y"
+  [ ! -f "$TEST_TMP/default/.github/instructions/caveman.instructions.md" ]
+  [ ! -f "$TEST_TMP/default/.claude/agents/caveman.md" ]
+  [ ! -f "$TEST_TMP/default/.cursor/agents/caveman.md" ]
+}


### PR DESCRIPTION
## Description

Closes #53. Adds end-to-end integration coverage for the opt-in `--caveman` deploy across Copilot / Claude / Cursor.

`tests/integration/deploy_all_platforms.bats` predates the caveman-mode rollout (v0.6.0). The unit tests in `tests/unit/caveman_role.bats` exercise `add_optional_role_to_project()` and the `INCLUDE_CAVEMAN` gate directly, but no test runs the *full wizard pipeline* with `--caveman` — so a regression that breaks caveman deploy on, say, Cursor only would slip through CI.

This PR closes that gap with a new sibling file rather than extending the existing one (decision: cleaner separation, the file is self-contained).

## Type of change

- [x] Tests

## What changes?

### `tests/integration/deploy_caveman.bats` (new)

8 scenarios, all running the full `bash wizard.sh --caveman` non-interactively:

- All 3 platforms: caveman role files appear at the expected paths (Copilot `.github/instructions/`, Claude `.claude/agents/`, Cursor `.cursor/agents/`).
- Frontmatter shape per platform (`name: caveman`, `model:`, `tools:` for Claude; `name: caveman` for Cursor).
- `docs/team-roster.md` gets a Caveman row.
- No leftover `{{PLACEHOLDER}}` tokens in deployed caveman files.
- Per-platform isolation: `--caveman` with Claude-only and Cursor-only deploys land only the right file.
- Control: wizard **without** `--caveman` does NOT deploy any caveman files (default opt-in behaviour).

A small helper `run_wizard_with_flags` mirrors the pattern of `run_wizard_noninteractive` from the existing file but accepts CLI flags before the platform answers, so the file stays drop-in with no shared mutation of the existing helper.

### `CONTRIBUTING.md`

- Adds `deploy_caveman.bats` to the test-tree diagram.
- Updates the "Where to put new tests" table so the `caveman` row points at both the unit and integration files.

### `CHANGELOG.md`

- Entry under `[Unreleased] -> Added`.

## How to test

- Locally with bats-core 1.13.0 on Git Bash (Windows): all 8 new tests pass (`bats tests/integration/deploy_caveman.bats` → 8/8 ok in 2m16s on this slow filesystem; will be much faster on Linux runners).
- CI bats jobs on `ubuntu-latest` and `macos-latest` will exercise it on each push.

## Checklist

- [x] Conventional Commits (`test(caveman):`)
- [x] CHANGELOG.md updated under `[Unreleased] -> Added`
- [x] New tests cover happy path (all 3 platforms, per-platform isolation) and at least one negative case (default does NOT deploy)
- [x] No production code changes
- [x] No breaking changes
