### PR TITLE
ci: add evals workflow with real tiktoken (workflow_dispatch + weekly)

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -1,0 +1,85 @@
+name: Evals (real tiktoken)
+
+# Regenerates tests/evals/RESULTS.md with real cl100k_base token counts
+# instead of the word-count fallback. Triggered manually by maintainers
+# (workflow_dispatch) or once a week (schedule). Uploads RESULTS.md as a
+# workflow artifact — a maintainer commits it to the repo when the numbers
+# change meaningfully.
+#
+# Non-blocking: not a required check on PRs. The lightweight smoke version
+# that runs on PRs lives in evals-smoke.yml.
+#
+# Tracked by issue #43.
+
+on:
+  workflow_dispatch:
+    inputs:
+      python-version:
+        description: "Python version (default 3.12; pick 3.11/3.12/3.13 if a wheel is missing)"
+        required: false
+        default: "3.12"
+  schedule:
+    # Mondays at 06:00 UTC. Cheap (Linux job, ~30s) and surfaces wheel
+    # regressions early. Adjust if it turns into noise.
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  evals:
+    name: "Evals (cl100k_base)"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ github.event.inputs.python-version || '3.12' }}
+
+      - name: Install tiktoken
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tiktoken
+
+      - name: Confirm tiktoken is on sys.path
+        run: python -c "import tiktoken; print('tiktoken', tiktoken.__version__)"
+
+      - name: Make compressor and harness executable
+        run: chmod +x scripts/understudy-compress tests/evals/run.sh
+
+      - name: Run evals harness with real tiktoken
+        run: ./tests/evals/run.sh
+
+      - name: Sanity-check that RESULTS.md uses cl100k_base
+        run: |
+          if ! grep -q "cl100k_base" tests/evals/RESULTS.md; then
+            echo "::error::tests/evals/RESULTS.md does not declare cl100k_base — tiktoken did not pick up." >&2
+            head -40 tests/evals/RESULTS.md >&2 || true
+            exit 1
+          fi
+
+      - name: Surface RESULTS.md head in job summary
+        run: |
+          {
+            echo "### Evals (cl100k_base, tiktoken)"
+            echo
+            echo '_Authoritative token counts. The lightweight word-count smoke runs in `evals-smoke.yml` on PRs._'
+            echo
+            echo '<details><summary>RESULTS.md (head)</summary>'
+            echo
+            echo '```markdown'
+            head -80 tests/evals/RESULTS.md
+            echo '```'
+            echo
+            echo '</details>'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload RESULTS.md as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: evals-RESULTS-${{ github.run_id }}
+          path: tests/evals/RESULTS.md
+          if-no-files-found: error
+          retention-days: 90

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ tmp/
 
 __pycache__/
 *.pyc
+
+# ── Python virtualenvs (e.g. .venv-evals/ for tests/evals/) ──
+.venv/
+.venv-*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   Uses the word-count fallback (no `tiktoken` install) so the job stays
   fast. The companion issue #43 covers regenerating `RESULTS.md` with
   real `tiktoken` numbers.
+- **Evals workflow with real `tiktoken`** (`.github/workflows/evals.yml`):
+  manual (`workflow_dispatch`) and weekly (Mon 06:00 UTC) job that
+  installs `tiktoken`, runs the harness with `cl100k_base`, fails if
+  `RESULTS.md` does not declare `cl100k_base`, and uploads it as a
+  workflow artifact. Non-blocking, not a required PR check. Local
+  recipes for `uv` / `python -m venv` / `pipx` are documented in
+  `tests/evals/README.md`.
 - **Release date guard**: `.github/workflows/release.yml` now validates
   that the date in `## [X.Y.Z] - YYYY-MM-DD` is within ±1 day (UTC) of
   the release run, so a forgotten CHANGELOG date bump fails the workflow

--- a/tests/evals/README.md
+++ b/tests/evals/README.md
@@ -51,6 +51,79 @@ pipx install tiktoken
 The compress script ships its own optional-tiktoken consent flow; the evals
 harness does not prompt — it just uses what is on `sys.path`.
 
+## Regenerating `RESULTS.md` with real `cl100k_base` numbers
+
+The committed `RESULTS.md` should declare `Token method: cl100k_base`. There
+are two supported ways to regenerate it.
+
+### Route A — CI workflow (canonical)
+
+`.github/workflows/evals.yml` runs the harness on `ubuntu-latest` with
+`tiktoken` pre-installed and uploads the regenerated `RESULTS.md` as a
+build artifact. The maintainer commits it to the repo when the numbers
+change meaningfully.
+
+Triggers:
+
+- **Manual** (`workflow_dispatch`): Actions tab → *Evals (real tiktoken)*
+  → *Run workflow*. Optional input pins the Python version (default `3.12`).
+- **Weekly** (`schedule`): Mondays 06:00 UTC. Catches `tiktoken` wheel
+  regressions early.
+
+The job is **non-blocking** and **not a required PR check** — the harness
+is opt-in by design. The lightweight word-count smoke that runs on PRs
+touching the compressor lives in `evals-smoke.yml`.
+
+### Route B — Local personal machine
+
+Pick whichever Python toolchain matches your environment. Each recipe ends
+with `./tests/evals/run.sh` and produces a `RESULTS.md` labelled
+`Token method: cl100k_base`. Commit it from the repo root.
+
+#### `uv` (recommended; installs its own Python 3.12)
+
+```bash
+uv venv --python 3.12 .venv-evals
+# Bash / zsh:
+source .venv-evals/bin/activate
+# Windows PowerShell:
+# .venv-evals\Scripts\Activate.ps1
+uv pip install tiktoken
+./tests/evals/run.sh
+```
+
+#### Stock `python3.12` + `pip`
+
+```bash
+python3.12 -m venv .venv-evals
+# Bash / zsh:
+source .venv-evals/bin/activate
+# Windows PowerShell:
+# .venv-evals\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+python -m pip install tiktoken
+./tests/evals/run.sh
+```
+
+#### `pipx` (system-wide, no venv juggling)
+
+```bash
+pipx install tiktoken
+./tests/evals/run.sh
+```
+
+> **Corporate proxy?** Most TLS-inspecting proxies (e.g. Zscaler) return
+> 403 for `files.pythonhosted.org` and break `pip install tiktoken`. If
+> you hit that, fall back to **Route A** — the CI workflow has clean
+> network access — and skip the local install.
+
+> **Python 3.14?** As of this writing there is no `tiktoken` wheel for
+> CPython 3.14. Pin to 3.12 (or whichever the latest version with a
+> published wheel is) for the venv above.
+
+The repo `.gitignore` already covers `.venv*`, so the harness venv will
+not be committed by accident.
+
 ## Methodology notes
 
 ### What this harness measures


### PR DESCRIPTION
## Description

Refs #43. Adds the canonical CI route (Route A) for regenerating `tests/evals/RESULTS.md` with real `cl100k_base` `tiktoken` counts, and documents the local recipes (Route B). The committed `RESULTS.md` is **not** updated in this PR — that is a deliberate follow-up once the workflow has produced an artifact on `main`. The issue stays open until then.

The maintainer machine cannot install `tiktoken` (Zscaler corporate proxy returns 403 against `files.pythonhosted.org`), so CI is the source of truth for this number.

## Type of change

- [x] CI / tooling
- [x] Documentation

## What changes?

### `.github/workflows/evals.yml` (new)

- Triggers: `workflow_dispatch` (with optional `python-version` input, default `3.12`) and a weekly `schedule` (Mondays 06:00 UTC).
- Steps: checkout → `setup-python` → `pip install tiktoken` → confirm import → `chmod +x` compressor & harness → `./tests/evals/run.sh` → grep `cl100k_base` from `RESULTS.md` (fail if missing) → post head of `RESULTS.md` to the job summary → upload `RESULTS.md` as a 90-day retention artifact named `evals-RESULTS-<run_id>`.
- **Non-blocking**, **not a required PR check**. The lightweight word-count smoke for PRs lives in `evals-smoke.yml`.

### `tests/evals/README.md`

- New "Regenerating `RESULTS.md` with real `cl100k_base` numbers" section.
- Route A: explains the CI workflow and how to trigger it manually.
- Route B: three local recipes — `uv`, stock `python3.12 -m venv`, `pipx`.
- Notes corporate-proxy and Python-3.14 caveats explicitly.

### `.gitignore`

- Adds `.venv/` and `.venv-*/` so the documented `.venv-evals/` venv cannot be committed by accident.

### `CHANGELOG.md`

- Entry under `[Unreleased] -> Added`.

## How to test

- Workflow YAML is well-formed; the existing `evals-smoke.yml` mirrors most of the same patterns (`actions/checkout@v4`, `actions/setup-python@v5`, `chmod +x`, awk over `RESULTS.md`).
- After this PR merges, I will dispatch the workflow on `main` from the Actions tab, download the artifact, and open a follow-up PR that commits the regenerated `RESULTS.md`. That PR will close #43.
- Existing required CI checks (bats, shellcheck, markdown lint, etc.) run on this PR and must stay green. The new workflow does not run on PRs (no `pull_request:` trigger).

## Checklist

- [x] Conventional Commits (`ci:`)
- [x] CHANGELOG.md updated under `[Unreleased] -> Added`
- [x] No bats tests required (workflow + docs + .gitignore only)
- [x] No breaking changes
