### PR TITLE
ci(release): build tarball with git archive + .gitattributes (#45)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,27 @@
+# `git archive` configuration for the release tarball.
+#
+# .github/workflows/release.yml builds the published tarball with
+# `git archive`, which by default packs every tracked file. The entries
+# below opt-out the dev-only paths so they do NOT ship inside
+# understudy-vX.Y.Z.tar.gz.
+#
+# Tracked by issue #45. If you add a new top-level file or directory and
+# it is dev-only (tests, CI, contributor docs), add it here.
+#
+# IMPORTANT: every pattern below is anchored to the repository root with
+# a leading slash. Without it, gitattributes globs are unanchored and
+# would also match nested paths (e.g. `.github/` would also strip
+# `templates/.github/`, and on case-insensitive filesystems `SECURITY.md`
+# would also strip `templates/.../security.md`).
+
+# ── CI / contributor / test scaffolding (dev-only) ────────────────────
+/.github/            export-ignore
+/tests/              export-ignore
+/run_tests.sh        export-ignore
+/.gitattributes      export-ignore
+/.gitignore          export-ignore
+
+# ── Contributor / governance docs (not part of the runtime) ───────────
+/CONTRIBUTING.md     export-ignore
+/CODE_OF_CONDUCT.md  export-ignore
+/SECURITY.md         export-ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,29 +77,35 @@ jobs:
           echo "CHANGELOG date ${declared} is within +/- 1 day of release date ${today} (UTC). OK."
 
       - name: Build release tarball
+        id: tarball
         run: |
           version="${{ steps.version.outputs.version }}"
           archive="understudy-${version}.tar.gz"
 
-          # Pack only what users need — no tests, no CI, no dev tooling.
-          # NOTE: do NOT use --exclude='.github' here — it would also strip
-          # templates/.github/ (the Copilot templates). The listed paths
-          # already omit the repo's top-level .git, .github and tests dirs.
-          tar -czf "$archive" \
-            --exclude='*.tar.gz' \
-            wizard.sh \
-            install.sh \
-            understudy.yaml \
-            templates \
-            roles \
-            scripts \
-            docs \
-            README.md \
-            CHANGELOG.md \
-            LICENSE
+          # Use `git archive` so the tarball stays in sync with the repo
+          # contents automatically. Dev-only paths (.github/, tests/,
+          # CONTRIBUTING.md, ...) are filtered out via `export-ignore`
+          # entries in .gitattributes — see issue #45.
+          #
+          # `--worktree-attributes` makes git read .gitattributes from the
+          # working tree (the file is itself `export-ignore`d, so it does
+          # not ship inside the tarball).
+          # No `--prefix` is set: install.sh extracts with
+          # `--strip-components=0`, which assumes a flat tarball.
+          git archive \
+            --format=tar.gz \
+            --worktree-attributes \
+            -o "$archive" \
+            HEAD
 
           echo "archive=$archive" >> "$GITHUB_OUTPUT"
-        id: tarball
+
+      - name: Show tarball contents
+        run: |
+          archive="${{ steps.tarball.outputs.archive }}"
+          echo "Tarball contents ($archive):"
+          tar tzf "$archive" | sort
+          echo "Total entries: $(tar tzf "$archive" | wc -l)"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- **Release tarball is now built with `git archive`** instead of an
+  explicit `tar -czf <list>`. The set of dev-only paths to omit lives
+  in `.gitattributes` (`export-ignore`), so adding a new top-level
+  runtime directory no longer requires a coordinated workflow change —
+  the tarball stays in sync with the repo tree automatically. This
+  closes the regression class that produced the v0.6.1 hotfix
+  (`scripts/` was missing from v0.6.0). Closes #45.
 - **Caveman roadmap is now discoverable**: the Deferred items in
   `docs/11-caveman-mode.md` § Not shipped are tracked as labelled
   (`caveman`) issues — hooks (#59), statusline (#60), and slash


### PR DESCRIPTION
## Description

Closes #45.

Switches the release tarball build in `.github/workflows/release.yml` from an explicit `tar -czf <list>` to `git archive --worktree-attributes`. The set of dev-only paths to omit now lives in `.gitattributes` via `export-ignore`, so adding a new top-level runtime directory no longer requires a coordinated workflow change — the tarball follows the repo tree automatically.

This closes the regression class that caused the **v0.6.1 hotfix** (the `scripts/` directory was forgotten in the explicit list when v0.6.0 introduced it).

## What changes?

- New `.gitattributes` at repo root with `export-ignore` for dev-only paths (CI, tests, contributor docs).
- `.github/workflows/release.yml`:
  - `Build release tarball` step replaced with `git archive --format=tar.gz --worktree-attributes -o <archive> HEAD`.
  - New `Show tarball contents` step prints `tar tzf | sort` for visibility on every release.
- `CHANGELOG.md` `[Unreleased] → Changed` entry.

### Design decisions

**1. Anchored patterns.** Every entry in `.gitattributes` uses a leading `/` (e.g. `/.github/`, `/SECURITY.md`). Without it, gitattributes globs are unanchored and:

- `.github/` would also strip `templates/.github/` (the entire Copilot template tree).
- `SECURITY.md` would also strip `templates/.claude/agents/security.md` and `templates/.cursor/agents/security.md` on case-insensitive filesystems (Windows / macOS-default APFS).

I caught both during local validation.

**2. No `--prefix`.** `install.sh` extracts with `--strip-components=0`, which assumes a flat tarball. Keeping the build flat is a one-line change with zero install-side impact. Using `--prefix=understudy-vX.Y.Z/` would be more idiomatic but would require bumping `install.sh` to `--strip-components=1` in the same PR — out of scope and not worth the churn.

**3. `docs/` stays in the runtime tarball.** The previous `tar` list included `docs/`; the new build does too. The issue checkbox is answered: ship docs.

## How to test

Locally compared the new and old tarballs:

```
old=86 new=86
=== DIFF (- only OLD, + only NEW) ===
(empty)
```

86 entries in both, identical contents. No drift.

CI on this PR validates YAML / shell syntax. After merge, the next real release tag will exercise the new path; the new `Show tarball contents` step prints the full file list in the workflow log for ongoing visibility.

## Type of change

- [x] Refactor / chore (no user-visible behavior change)
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Tests / CI

## Checklist

- [x] CHANGELOG updated
- [x] Local parity check passes (86 == 86, diff empty)
- [x] No change required in `install.sh` (no `--prefix` used)
- [x] Conventional commit message
