### PR TITLE
feat: caveman slash commands across Claude/Copilot/Cursor (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- **Caveman slash commands** (closes #61):
+  `modules/caveman/bin/install-commands` ships a `/compress` and a
+  `/restore` slash command in each platform's native location:
+  `.claude/commands/*.md` for Claude Code,
+  `.github/prompts/*.prompt.md` for GitHub Copilot / VS Code, and
+  `.cursor/commands/*.md` for Cursor. Each shipped file carries a
+  `<!-- caveman:command -->` sentinel; uninstall only removes files that
+  still carry it, so a user who overrides one with their own version
+  will see their file preserved. The wizard exposes the new automation
+  via `./wizard.sh --caveman --caveman-commands`, registered
+  declaratively from `modules/caveman/post-install.flags`.
 - **Caveman reinforcement hooks** (closes #59):
   `modules/caveman/bin/install-hooks` wires terse-style reinforcement
   into a project on opt-in. On Claude Code it installs real hooks via

--- a/docs/11-caveman-mode.md
+++ b/docs/11-caveman-mode.md
@@ -177,7 +177,7 @@ port (yet). Each was evaluated and consciously deferred:
 | --- | --- | --- |
 | Pre/post-prompt **hooks** | **Shipped** ([#59](https://github.com/erniker/understudy/issues/59)) | See [Reinforcement hooks](#reinforcement-hooks-issue-59) below. Claude Code uses real hooks; Copilot and Cursor get a degraded equivalent. |
 | **Statusline** | Deferred ([#60](https://github.com/erniker/understudy/issues/60)) | Claude-only. Limited cross-platform value. |
-| **Slash commands** for compression | Deferred ([#61](https://github.com/erniker/understudy/issues/61)) | Each platform has its own command grammar; needs a separate design. |
+| **Slash commands** for compression | **Shipped** ([#61](https://github.com/erniker/understudy/issues/61)) | See [Slash commands](#slash-commands-issue-61) below. Each platform gets a native file in its conventional location. |
 | **wenyan** (Classical Chinese post-processor) | Skipped | Out of scope for an English-language ops tool. |
 | **Token evaluation harness** | **Shipped** in [`modules/caveman/evals/`](../modules/caveman/evals/README.md) | Dogfood + 3-arm methodology (no-caveman / role / role+compress). Opt-in; not wired into `run_tests.sh`. |
 
@@ -229,6 +229,45 @@ modules/caveman/bin/install-hooks uninstall
 Caveman-owned entries in `settings.json` are tagged with `__caveman`, so
 the uninstaller never touches hooks installed by other tools (for
 example the existing `PreToolUse` guardrails hook).
+
+---
+
+## Slash commands (issue #61)
+
+The same compressor can be invoked from inside the AI client through a
+platform-native slash command. Each platform exposes commands its own
+way, so the installer drops a file in the conventional location for
+each:
+
+| Platform | Where it lands | How to invoke |
+| --- | --- | --- |
+| Claude Code | `.claude/commands/compress.md`, `restore.md` | `/compress <path>` and `/restore <path>` |
+| GitHub Copilot / VS Code | `.github/prompts/compress.prompt.md`, `restore.prompt.md` | Run the prompt file from Copilot Chat |
+| Cursor | `.cursor/commands/compress.md`, `restore.md` | `/compress <path>` and `/restore <path>` |
+
+Wire it up at deploy time:
+
+```bash
+./wizard.sh --caveman --caveman-commands
+```
+
+Or against an existing deployment:
+
+```bash
+modules/caveman/bin/install-commands install
+modules/caveman/bin/install-commands uninstall
+```
+
+Each shipped file carries a `<!-- caveman:command -->` sentinel.
+Uninstall only removes files that still carry it, so a user who
+overrides `compress.md` with their own version will see their file
+preserved on uninstall.
+
+The commands are thin wrappers around
+`modules/caveman/bin/understudy-compress`, so the same safety contract
+applies (refuses files outside CWD, `.env*`/secret-named files,
+symlinks, and content matching common credential patterns; always
+creates a `<file>.original.md` byte-identical backup).
 
 ---
 

--- a/modules/caveman/README.md
+++ b/modules/caveman/README.md
@@ -11,11 +11,13 @@ an Understudy deployment. Inspired by
 | [`role.instructions.md`](role.instructions.md) | The `caveman` role — terse, token-efficient prose style. |
 | [`bin/understudy-compress`](bin/understudy-compress) | Python 3.8+ compressor that rewrites Markdown in place, preserving code/paths/URLs and creating a `.original.md` backup. |
 | [`bin/install-hooks`](bin/install-hooks) | Wires (or removes) caveman reinforcement hooks into a project — Claude Code real hooks, plus degraded reinforcement blocks for Copilot and Cursor. |
+| [`bin/install-commands`](bin/install-commands) | Wires (or removes) caveman slash commands (`/compress`, `/restore`) for Claude, Copilot/VS Code and Cursor. |
 | [`bin/requirements.txt`](bin/requirements.txt) | Optional `tiktoken` for accurate `cl100k_base` token measurements. |
 | [`hooks/`](hooks/) | Source assets installed by `install-hooks` (Claude `session-start.sh` / `user-prompt-submit.sh`, Copilot reinforcement block, Cursor `.mdc` rule). |
-| [`post-install.flags`](post-install.flags) | Declarative wizard hook so `./wizard.sh --caveman --caveman-hooks` runs `install-hooks` after deploy without editing `wizard.sh`. |
+| [`commands/`](commands/) | Source assets installed by `install-commands` (Claude `compress.md` / `restore.md`, Copilot `*.prompt.md`, Cursor `*.md`). |
+| [`post-install.flags`](post-install.flags) | Declarative wizard hooks so `./wizard.sh --caveman --caveman-hooks` / `--caveman-commands` run their installers after deploy without editing `wizard.sh`. |
 | [`evals/`](evals/) | Token-reduction evaluation harness (`run.sh` regenerates `RESULTS.md`). |
-| [`tests/`](tests/) | Bats coverage for the role, the compressor, the install-hooks installer and the wizard's `--caveman` / `--caveman-hooks` flags. |
+| [`tests/`](tests/) | Bats coverage for the role, the compressor, the installers and the wizard's `--caveman` / `--caveman-hooks` / `--caveman-commands` flags. |
 
 The user-facing chapter for caveman lives in
 [`docs/11-caveman-mode.md`](../../docs/11-caveman-mode.md) (kept at its
@@ -63,6 +65,39 @@ modules/caveman/bin/install-hooks uninstall
 
 Caveman-owned entries are tagged with `__caveman` in `settings.json` so
 the uninstall never disturbs hooks added by other tools.
+
+## How to enable the slash commands (issue #61)
+
+Each platform has its own grammar for slash commands, so the installer
+ships a platform-native file in the conventional location for each:
+
+```bash
+./wizard.sh --caveman --caveman-commands    # opt in at deploy time
+# or, on an existing deployment:
+modules/caveman/bin/install-commands install
+```
+
+| Platform | Where it lands | How to invoke |
+| --- | --- | --- |
+| Claude Code | `.claude/commands/compress.md` and `restore.md` | `/compress <path>` and `/restore <path>` |
+| GitHub Copilot / VS Code | `.github/prompts/compress.prompt.md` and `restore.prompt.md` | Copilot Chat → run prompt file |
+| Cursor | `.cursor/commands/compress.md` and `restore.md` | `/compress <path>` and `/restore <path>` |
+
+Both commands proxy through `modules/caveman/bin/understudy-compress` so
+the same safety contract applies (refuses to operate on files outside
+CWD, on `.env*`/secret-named files, on symlinks, and on content matching
+common credential patterns; always creates a `<file>.original.md`
+backup).
+
+To remove the commands:
+
+```bash
+modules/caveman/bin/install-commands uninstall
+```
+
+Each shipped file carries a `<!-- caveman:command -->` sentinel; the
+uninstaller only removes files that still carry it, so user-authored
+files in the same directory are never touched.
 
 ## How to remove the module entirely
 

--- a/modules/caveman/bin/install-commands
+++ b/modules/caveman/bin/install-commands
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# install-commands — wire (or remove) caveman slash commands for the
+# active AI platforms in a project.
+#
+# Each platform has its own slash-command grammar, so this installer
+# copies platform-native files into their conventional locations:
+#
+#   - Claude Code: .claude/commands/<name>.md
+#   - GitHub Copilot / VS Code: .github/prompts/<name>.prompt.md
+#   - Cursor: .cursor/commands/<name>.md
+#
+# All files include a "<!-- caveman:command -->" sentinel so uninstall
+# only removes files we own — files with the same name written by the
+# user or another tool are left alone.
+#
+# USAGE
+#   modules/caveman/bin/install-commands install   [options]
+#   modules/caveman/bin/install-commands uninstall [options]
+#
+# OPTIONS
+#   --target  PATH      Project root to install into. Default: cwd.
+#   --platforms LIST    Comma-separated subset of claude,copilot,cursor.
+#                       Default: auto-detect from existing .claude/,
+#                       .github/, .cursor/.
+#   -h, --help          Show this help.
+#
+# EXIT CODES
+#   0  success
+#   1  usage error / target missing
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_DIR="$(cd "${HERE}/.." && pwd)"
+COMMANDS_SRC="${MODULE_DIR}/commands"
+SENTINEL='<!-- caveman:command'
+
+# Defaults
+ACTION=""
+TARGET="$(pwd)"
+PLATFORMS=""
+
+# Command names per platform. Filenames in the source tree.
+CLAUDE_CMDS=(compress.md restore.md)
+COPILOT_CMDS=(compress.prompt.md restore.prompt.md)
+CURSOR_CMDS=(compress.md restore.md)
+
+# ── Helpers ──────────────────────────────────────────────────────────
+die() { printf 'install-commands: error: %s\n' "$*" >&2; exit 1; }
+note() { printf '[install-commands] %s\n' "$*"; }
+
+usage() {
+    sed -n '2,/^set -euo/p' "${BASH_SOURCE[0]}" | sed -e 's/^# \{0,1\}//' -e '$d'
+}
+
+detect_platforms() {
+    local detected=""
+    [[ -d "${TARGET}/.claude"  ]] && detected="${detected:+${detected},}claude"
+    [[ -d "${TARGET}/.github"  ]] && detected="${detected:+${detected},}copilot"
+    [[ -d "${TARGET}/.cursor"  ]] && detected="${detected:+${detected},}cursor"
+    printf '%s' "$detected"
+}
+
+has_platform() { [[ ",${PLATFORMS}," == *",$1,"* ]]; }
+
+# Install one command file: copy from src to dst, creating the parent
+# directory. Always overwrite (idempotent).
+install_one() {
+    local src="$1" dst="$2"
+    [[ -f "$src" ]] || die "missing source command file: $src"
+    mkdir -p "$(dirname "$dst")"
+    cp "$src" "$dst"
+}
+
+# Remove one command file but only if it carries the caveman sentinel.
+# This protects user-authored files that happen to share the name.
+uninstall_one() {
+    local dst="$1"
+    [[ -f "$dst" ]] || return 0
+    if grep -qF "$SENTINEL" "$dst"; then
+        rm -f "$dst"
+    else
+        note "skipping $dst (no caveman sentinel — left untouched)"
+    fi
+}
+
+# ── Argument parsing ────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        install|uninstall)   ACTION="$1"; shift ;;
+        --target)            TARGET="${2:?--target requires a value}"; shift 2 ;;
+        --platforms)         PLATFORMS="${2:?--platforms requires a value}"; shift 2 ;;
+        -h|--help)           usage; exit 0 ;;
+        *)                   die "unknown argument: $1" ;;
+    esac
+done
+
+[[ -n "$ACTION" ]]               || die "missing action (install|uninstall)"
+[[ -d "$TARGET" ]]               || die "target directory does not exist: $TARGET"
+
+[[ -n "$PLATFORMS" ]] || PLATFORMS="$(detect_platforms)"
+[[ -n "$PLATFORMS" ]] || die "no AI platforms detected under $TARGET (need .claude, .github or .cursor)"
+
+TARGET="$(cd "$TARGET" && pwd)"
+
+# ── Claude ──────────────────────────────────────────────────────────
+if has_platform "claude"; then
+    dest_dir="${TARGET}/.claude/commands"
+    if [[ "$ACTION" == "install" ]]; then
+        for f in "${CLAUDE_CMDS[@]}"; do
+            install_one "${COMMANDS_SRC}/claude/${f}" "${dest_dir}/${f}"
+        done
+        note "Claude commands installed under .claude/commands/ (${CLAUDE_CMDS[*]})"
+    else
+        for f in "${CLAUDE_CMDS[@]}"; do
+            uninstall_one "${dest_dir}/${f}"
+        done
+        note "Claude commands removed"
+    fi
+fi
+
+# ── Copilot / VS Code ──────────────────────────────────────────────
+if has_platform "copilot"; then
+    dest_dir="${TARGET}/.github/prompts"
+    if [[ "$ACTION" == "install" ]]; then
+        for f in "${COPILOT_CMDS[@]}"; do
+            install_one "${COMMANDS_SRC}/copilot/${f}" "${dest_dir}/${f}"
+        done
+        note "Copilot prompts installed under .github/prompts/ (${COPILOT_CMDS[*]})"
+    else
+        for f in "${COPILOT_CMDS[@]}"; do
+            uninstall_one "${dest_dir}/${f}"
+        done
+        note "Copilot prompts removed"
+    fi
+fi
+
+# ── Cursor ──────────────────────────────────────────────────────────
+if has_platform "cursor"; then
+    dest_dir="${TARGET}/.cursor/commands"
+    if [[ "$ACTION" == "install" ]]; then
+        for f in "${CURSOR_CMDS[@]}"; do
+            install_one "${COMMANDS_SRC}/cursor/${f}" "${dest_dir}/${f}"
+        done
+        note "Cursor commands installed under .cursor/commands/ (${CURSOR_CMDS[*]})"
+    else
+        for f in "${CURSOR_CMDS[@]}"; do
+            uninstall_one "${dest_dir}/${f}"
+        done
+        note "Cursor commands removed"
+    fi
+fi
+
+note "Done."

--- a/modules/caveman/commands/claude/compress.md
+++ b/modules/caveman/commands/claude/compress.md
@@ -1,0 +1,33 @@
+---
+name: compress
+description: "Caveman: compress a Markdown file in place using understudy-compress (preserves code/paths/URLs, creates a .original.md backup)."
+__caveman: true
+---
+
+<!-- caveman:command — managed by modules/caveman/bin/install-commands -->
+
+Run the caveman compressor on the provided path and report the token / word
+savings.
+
+Target file: `$ARGUMENTS`
+
+Steps:
+
+1. Verify the path exists and is a regular file inside the current
+   workspace. If not, stop and explain.
+2. Run `modules/caveman/bin/understudy-compress "$ARGUMENTS"` from the
+   project root (fall back to `scripts/understudy-compress` for legacy
+   layouts).
+3. Report:
+   - bytes / words / tokens before and after,
+   - location of the `.original.md` backup,
+   - how to restore (`/restore <path>` or `understudy-compress --restore <path>`).
+4. Do **not** stage or commit the change. The user will review the diff
+   first.
+
+Safety reminders for the caveman compressor:
+
+- Refuses to operate on files outside CWD, on `.env*` / secret-named
+  files, on symlinks, and on content matching common credential patterns.
+- Always creates a byte-identical backup at `<file>.original.md`.
+- `--dry-run` previews savings without modifying the file.

--- a/modules/caveman/commands/claude/restore.md
+++ b/modules/caveman/commands/claude/restore.md
@@ -1,0 +1,24 @@
+---
+name: restore
+description: "Caveman: restore a Markdown file from its .original.md backup (byte-identical) and remove the backup."
+__caveman: true
+---
+
+<!-- caveman:command — managed by modules/caveman/bin/install-commands -->
+
+Restore the file at `$ARGUMENTS` to the byte-identical content of its
+`.original.md` backup, then remove the backup.
+
+Steps:
+
+1. Verify both `$ARGUMENTS` and `<$ARGUMENTS>.original.md` exist.
+2. Run `modules/caveman/bin/understudy-compress --restore "$ARGUMENTS"`
+   (fall back to `scripts/understudy-compress --restore` for legacy
+   layouts).
+3. Confirm the file is back to the pre-compression content and that the
+   backup file has been removed.
+4. Do **not** stage or commit. The user reviews the diff first.
+
+If no backup exists, stop and tell the user: there is nothing to restore
+because the file was never compressed (or the backup has already been
+consumed by a previous `--restore`).

--- a/modules/caveman/commands/copilot/compress.prompt.md
+++ b/modules/caveman/commands/copilot/compress.prompt.md
@@ -1,0 +1,30 @@
+---
+mode: 'agent'
+description: 'Caveman: compress a Markdown file in place using understudy-compress (preserves code/paths/URLs, creates a .original.md backup).'
+__caveman: true
+---
+
+<!-- caveman:command — managed by modules/caveman/bin/install-commands -->
+
+Run the caveman compressor on the file the user names in this prompt.
+
+Steps:
+
+1. Ask the user for the target path if they did not provide one.
+2. Verify the path exists and is a regular file inside the current
+   workspace.
+3. Run `modules/caveman/bin/understudy-compress <path>` from the project
+   root (fall back to `scripts/understudy-compress` for legacy layouts).
+4. Report bytes / words / tokens before and after, the backup location
+   (`<path>.original.md`), and how to undo
+   (`@workspace /restore <path>` or
+   `understudy-compress --restore <path>`).
+5. Do **not** stage or commit. The user will review the diff.
+
+Safety reminders for the caveman compressor:
+
+- Refuses to operate on files outside the current working directory, on
+  `.env*` / secret-named files, on symlinks, and on content matching
+  common credential patterns (RSA / OpenSSH / AWS keys).
+- Always creates a byte-identical backup at `<file>.original.md`.
+- `--dry-run` previews savings without modifying the file.

--- a/modules/caveman/commands/copilot/restore.prompt.md
+++ b/modules/caveman/commands/copilot/restore.prompt.md
@@ -1,0 +1,25 @@
+---
+mode: 'agent'
+description: 'Caveman: restore a Markdown file from its .original.md backup (byte-identical) and remove the backup.'
+__caveman: true
+---
+
+<!-- caveman:command — managed by modules/caveman/bin/install-commands -->
+
+Restore the file the user names in this prompt to the byte-identical
+content of its `.original.md` backup, then remove the backup.
+
+Steps:
+
+1. Ask the user for the target path if they did not provide one.
+2. Verify both the target file and `<target>.original.md` exist.
+3. Run `modules/caveman/bin/understudy-compress --restore <path>` from
+   the project root (fall back to `scripts/understudy-compress --restore`
+   for legacy layouts).
+4. Confirm the file is back to the pre-compression content and that the
+   backup file has been removed.
+5. Do **not** stage or commit. The user reviews the diff first.
+
+If no backup exists, stop and tell the user: there is nothing to restore
+because the file was never compressed (or the backup has already been
+consumed by a previous `--restore`).

--- a/modules/caveman/commands/cursor/compress.md
+++ b/modules/caveman/commands/cursor/compress.md
@@ -1,0 +1,30 @@
+---
+name: compress
+description: "Caveman: compress a Markdown file in place using understudy-compress (preserves code/paths/URLs, creates a .original.md backup)."
+__caveman: true
+---
+
+<!-- caveman:command — managed by modules/caveman/bin/install-commands -->
+
+Run the caveman compressor on the path the user provides and report the
+token / word savings.
+
+Steps:
+
+1. Ask the user for the target path if they did not provide one.
+2. Verify the path exists and is a regular file inside the current
+   workspace.
+3. Run `modules/caveman/bin/understudy-compress <path>` from the project
+   root (fall back to `scripts/understudy-compress` for legacy layouts).
+4. Report bytes / words / tokens before and after, the backup location
+   (`<path>.original.md`), and how to undo
+   (`/restore <path>` or `understudy-compress --restore <path>`).
+5. Do **not** stage or commit. The user will review the diff.
+
+Safety reminders for the caveman compressor:
+
+- Refuses to operate on files outside the current working directory, on
+  `.env*` / secret-named files, on symlinks, and on content matching
+  common credential patterns.
+- Always creates a byte-identical backup at `<file>.original.md`.
+- `--dry-run` previews savings without modifying the file.

--- a/modules/caveman/commands/cursor/restore.md
+++ b/modules/caveman/commands/cursor/restore.md
@@ -1,0 +1,25 @@
+---
+name: restore
+description: "Caveman: restore a Markdown file from its .original.md backup (byte-identical) and remove the backup."
+__caveman: true
+---
+
+<!-- caveman:command — managed by modules/caveman/bin/install-commands -->
+
+Restore the file the user provides to the byte-identical content of its
+`.original.md` backup, then remove the backup.
+
+Steps:
+
+1. Ask the user for the target path if they did not provide one.
+2. Verify both the target file and `<target>.original.md` exist.
+3. Run `modules/caveman/bin/understudy-compress --restore <path>` from
+   the project root (fall back to `scripts/understudy-compress --restore`
+   for legacy layouts).
+4. Confirm the file is back to the pre-compression content and that the
+   backup file has been removed.
+5. Do **not** stage or commit. The user reviews the diff first.
+
+If no backup exists, stop and tell the user: there is nothing to restore
+because the file was never compressed (or the backup has already been
+consumed by a previous `--restore`).

--- a/modules/caveman/post-install.flags
+++ b/modules/caveman/post-install.flags
@@ -10,3 +10,4 @@
 # This file is the contract that lets contributors ship optional
 # automation alongside a module without editing wizard.sh.
 --caveman-hooks	bin/install-hooks install --mode remind --target {TARGET}	Install caveman reinforcement hooks (Claude SessionStart + Copilot/Cursor reminder).
+--caveman-commands	bin/install-commands install --target {TARGET}	Install caveman slash commands: /compress and /restore for Claude, Copilot and Cursor.

--- a/modules/caveman/tests/commands.bats
+++ b/modules/caveman/tests/commands.bats
@@ -1,0 +1,136 @@
+#!/usr/bin/env bats
+# Tests for modules/caveman/bin/install-commands across the three target
+# platforms. Also covers wizard.sh wiring via --caveman-commands.
+
+load '../../../tests/lib/helpers'
+
+INSTALL_COMMANDS="${BATS_TEST_DIRNAME}/../bin/install-commands"
+
+setup() {
+    setup_tmp
+    cd "$TEST_TMP"
+    mkdir -p .claude .github .cursor
+}
+
+teardown() { teardown_tmp; }
+
+# ── Detection ────────────────────────────────────────────────────────
+
+@test "install-commands --help returns 0 and mentions install/uninstall" {
+    run "$INSTALL_COMMANDS" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"install"* ]]
+    [[ "$output" == *"uninstall"* ]]
+}
+
+@test "install-commands aborts when no AI platforms are present" {
+    rm -rf .claude .github .cursor
+    run "$INSTALL_COMMANDS" install
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"no AI platforms detected"* ]]
+}
+
+# ── Claude commands ──────────────────────────────────────────────────
+
+@test "install drops compress.md and restore.md under .claude/commands/" {
+    run "$INSTALL_COMMANDS" install --platforms claude
+    [ "$status" -eq 0 ]
+    [ -f .claude/commands/compress.md ]
+    [ -f .claude/commands/restore.md ]
+    grep -qF 'caveman:command' .claude/commands/compress.md
+    grep -qF 'caveman:command' .claude/commands/restore.md
+}
+
+@test "install is idempotent (reinstall does not duplicate or corrupt files)" {
+    "$INSTALL_COMMANDS" install --platforms claude
+    "$INSTALL_COMMANDS" install --platforms claude
+    [ -f .claude/commands/compress.md ]
+    # Single, well-formed frontmatter (only one `name: compress` line).
+    run grep -c '^name: compress$' .claude/commands/compress.md
+    [ "$output" -eq 1 ]
+}
+
+@test "uninstall removes only files carrying the caveman sentinel" {
+    "$INSTALL_COMMANDS" install --platforms claude
+    # User-authored file in the same directory: must survive uninstall.
+    printf 'user authored, no sentinel\n' > .claude/commands/my-own.md
+    run "$INSTALL_COMMANDS" uninstall --platforms claude
+    [ "$status" -eq 0 ]
+    [ ! -f .claude/commands/compress.md ]
+    [ ! -f .claude/commands/restore.md ]
+    [ -f .claude/commands/my-own.md ]
+}
+
+@test "uninstall preserves a user file that happens to share a name with a caveman command" {
+    "$INSTALL_COMMANDS" install --platforms claude
+    # Replace the caveman compress.md with a user-authored version (no sentinel).
+    printf -- '---\nname: compress\n---\n\nMy own override.\n' > .claude/commands/compress.md
+    run "$INSTALL_COMMANDS" uninstall --platforms claude
+    [ "$status" -eq 0 ]
+    [ -f .claude/commands/compress.md ]
+    grep -qF 'My own override' .claude/commands/compress.md
+}
+
+# ── Copilot prompts ─────────────────────────────────────────────────
+
+@test "install drops .prompt.md files under .github/prompts/" {
+    run "$INSTALL_COMMANDS" install --platforms copilot
+    [ "$status" -eq 0 ]
+    [ -f .github/prompts/compress.prompt.md ]
+    [ -f .github/prompts/restore.prompt.md ]
+    grep -qF 'caveman:command' .github/prompts/compress.prompt.md
+}
+
+@test "uninstall removes only sentinel-tagged Copilot prompts" {
+    "$INSTALL_COMMANDS" install --platforms copilot
+    printf 'user authored, no sentinel\n' > .github/prompts/my-own.prompt.md
+    run "$INSTALL_COMMANDS" uninstall --platforms copilot
+    [ "$status" -eq 0 ]
+    [ ! -f .github/prompts/compress.prompt.md ]
+    [ -f .github/prompts/my-own.prompt.md ]
+}
+
+# ── Cursor commands ─────────────────────────────────────────────────
+
+@test "install drops compress.md and restore.md under .cursor/commands/" {
+    run "$INSTALL_COMMANDS" install --platforms cursor
+    [ "$status" -eq 0 ]
+    [ -f .cursor/commands/compress.md ]
+    [ -f .cursor/commands/restore.md ]
+    grep -qF 'caveman:command' .cursor/commands/compress.md
+}
+
+@test "uninstall removes only sentinel-tagged Cursor commands" {
+    "$INSTALL_COMMANDS" install --platforms cursor
+    printf 'user authored, no sentinel\n' > .cursor/commands/my-own.md
+    run "$INSTALL_COMMANDS" uninstall --platforms cursor
+    [ "$status" -eq 0 ]
+    [ ! -f .cursor/commands/compress.md ]
+    [ -f .cursor/commands/my-own.md ]
+}
+
+# ── Wizard wiring ───────────────────────────────────────────────────
+
+@test "wizard --help lists --caveman-commands under post-install flags" {
+    run "$WIZARD" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--caveman-commands"* ]]
+}
+
+@test "discover_modules registers the --caveman-commands post-install flag" {
+    source_wizard_functions
+    run postinstall_index_by_flag --caveman-commands
+    [ "$status" -eq 0 ]
+}
+
+@test "post-install action is skipped if its module is not included" {
+    source_wizard_functions
+    local idx
+    idx="$(postinstall_index_by_flag --caveman-commands)"
+    POSTINSTALL_REQUESTED[$idx]=true
+    module_set_included caveman false
+    TARGET_DIR="$TEST_TMP"
+    run run_postinstall_actions
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Skipping --caveman-commands"* ]]
+}


### PR DESCRIPTION
## Description

Adds opt-in **caveman slash commands** in the native location of each supported AI client. Today the compressor lives in `modules/caveman/bin/understudy-compress` and users have to run it from the shell. With this PR they can invoke it from inside their assistant via `/compress <path>` and `/restore <path>` (Claude Code, Cursor) or by running a `.prompt.md` file from Copilot Chat (GitHub Copilot / VS Code).

The installer follows the same pattern introduced in #67 / #59: a small `bin/` script and a declarative `post-install.flags` line, so wiring it into the wizard required **zero edits to `wizard.sh`**.

Closes #61.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only

## What changes?

**New: `modules/caveman/bin/install-commands`** — `install` / `uninstall` subcommands with `--target PATH` and `--platforms LIST` (auto-detected by default).

| Platform | Where it lands | How to invoke |
| --- | --- | --- |
| Claude Code | `.claude/commands/compress.md`, `restore.md` | `/compress <path>`, `/restore <path>` |
| GitHub Copilot / VS Code | `.github/prompts/compress.prompt.md`, `restore.prompt.md` | Run prompt file from Copilot Chat |
| Cursor | `.cursor/commands/compress.md`, `restore.md` | `/compress <path>`, `/restore <path>` |

Each shipped file carries a `<!-- caveman:command -->` sentinel. The uninstaller only removes files that still carry it — verified with a test that overrides `compress.md` with a user-authored version (no sentinel) and asserts it survives uninstall.

The commands are thin wrappers around `understudy-compress`, so the same safety contract applies (refuses files outside CWD, `.env*`/secret-named files, symlinks, content matching credential patterns; always creates a `<file>.original.md` byte-identical backup).

**Wizard wiring:** `--caveman-commands` is added by appending one line to `modules/caveman/post-install.flags`. Discovery and execution reuse the `POSTINSTALL_*` registry shipped in #59 — no edits to `wizard.sh`.

**Docs:** `modules/caveman/README.md` (new "How to enable the slash commands" section + ships table updated), `docs/11-caveman-mode.md` (new "Slash commands (issue #61)" chapter; the "Not shipped" table flips #61 to **Shipped**), `CHANGELOG.md` (`[Unreleased] → Added`).

## How to test

```bash
# Unit/installer tests for commands (13 cases)
bats modules/caveman/tests/commands.bats

# Full suite (237 ok)
./run_tests.sh
```

End-to-end smoke in a temporary directory:

```bash
mkdir /tmp/cv-cmd-smoke && cd /tmp/cv-cmd-smoke
"$OLDPWD/wizard.sh" --here --yes --caveman --caveman-commands   # answer 'n' to git init
ls .claude/commands/ .github/prompts/ .cursor/commands/
# → compress.md restore.md / compress.prompt.md restore.prompt.md / compress.md restore.md

# Idempotent reinstall, sentinel-aware uninstall
"$OLDPWD/modules/caveman/bin/install-commands" install
"$OLDPWD/modules/caveman/bin/install-commands" uninstall
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] CHANGELOG.md updated under `[Unreleased]`
