### PR TITLE
feat: caveman compression-savings statusline for Claude Code (#60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- **Caveman compression-savings statusline** (closes #60):
+  `modules/caveman/bin/install-statusline` adds an opt-in Claude Code
+  statusline that walks every `*.original.md` backup left by the
+  compressor and reports cumulative byte savings as
+  `caveman: N files | -X bytes (-Y%)`. The statusline script is
+  read-only, exits 0 in every branch (so the line never disappears on
+  error), and skips backup files whose live counterpart was deleted.
+  Statusline is intentionally Claude-only because Copilot and Cursor do
+  not expose a statusline API. The `statusLine` entry in
+  `.claude/settings.json` is tagged with `__caveman: true` so uninstall
+  only clears the field if it is still owned by caveman. The wizard
+  exposes the new automation via
+  `./wizard.sh --caveman --caveman-statusline`, registered
+  declaratively from `modules/caveman/post-install.flags`.
 - **Caveman slash commands** (closes #61):
   `modules/caveman/bin/install-commands` ships a `/compress` and a
   `/restore` slash command in each platform's native location:

--- a/docs/11-caveman-mode.md
+++ b/docs/11-caveman-mode.md
@@ -176,7 +176,7 @@ port (yet). Each was evaluated and consciously deferred:
 | Feature | Status | Why deferred |
 | --- | --- | --- |
 | Pre/post-prompt **hooks** | **Shipped** ([#59](https://github.com/erniker/understudy/issues/59)) | See [Reinforcement hooks](#reinforcement-hooks-issue-59) below. Claude Code uses real hooks; Copilot and Cursor get a degraded equivalent. |
-| **Statusline** | Deferred ([#60](https://github.com/erniker/understudy/issues/60)) | Claude-only. Limited cross-platform value. |
+| **Statusline** | **Shipped** ([#60](https://github.com/erniker/understudy/issues/60)) | See [Statusline](#statusline-issue-60-claude-only) below. Claude Code only — the other platforms have no statusline API. |
 | **Slash commands** for compression | **Shipped** ([#61](https://github.com/erniker/understudy/issues/61)) | See [Slash commands](#slash-commands-issue-61) below. Each platform gets a native file in its conventional location. |
 | **wenyan** (Classical Chinese post-processor) | Skipped | Out of scope for an English-language ops tool. |
 | **Token evaluation harness** | **Shipped** in [`modules/caveman/evals/`](../modules/caveman/evals/README.md) | Dogfood + 3-arm methodology (no-caveman / role / role+compress). Opt-in; not wired into `run_tests.sh`. |
@@ -268,6 +268,43 @@ The commands are thin wrappers around
 applies (refuses files outside CWD, `.env*`/secret-named files,
 symlinks, and content matching common credential patterns; always
 creates a `<file>.original.md` byte-identical backup).
+
+---
+
+## Statusline (issue #60, Claude only)
+
+Claude Code is the only platform that exposes a statusline API today,
+so this feature is intentionally Claude-only. The statusline reports
+cumulative compression savings across the workspace by walking every
+`*.original.md` backup left by the compressor and comparing its size
+against the live counterpart.
+
+Wire it up at deploy time:
+
+```bash
+./wizard.sh --caveman --caveman-statusline
+```
+
+Or against an existing deployment:
+
+```bash
+modules/caveman/bin/install-statusline install
+modules/caveman/bin/install-statusline uninstall
+```
+
+What you see in the Claude Code prompt area:
+
+```text
+caveman: ready                                  # no backups yet
+caveman: 3 files | -1234 bytes (-23%)           # cumulative savings
+```
+
+The script is read-only, exits 0 in every branch (so the statusline
+never disappears on error), and skips backup files whose live
+counterpart was deleted. The `statusLine` entry in
+`.claude/settings.json` is tagged with `__caveman: true`, so uninstall
+only clears the field if it is still owned by caveman — a statusline
+installed by another tool is left untouched.
 
 ---
 

--- a/modules/caveman/README.md
+++ b/modules/caveman/README.md
@@ -12,12 +12,14 @@ an Understudy deployment. Inspired by
 | [`bin/understudy-compress`](bin/understudy-compress) | Python 3.8+ compressor that rewrites Markdown in place, preserving code/paths/URLs and creating a `.original.md` backup. |
 | [`bin/install-hooks`](bin/install-hooks) | Wires (or removes) caveman reinforcement hooks into a project — Claude Code real hooks, plus degraded reinforcement blocks for Copilot and Cursor. |
 | [`bin/install-commands`](bin/install-commands) | Wires (or removes) caveman slash commands (`/compress`, `/restore`) for Claude, Copilot/VS Code and Cursor. |
+| [`bin/install-statusline`](bin/install-statusline) | Wires (or removes) the Claude Code statusline that reports compression savings (Claude-only). |
 | [`bin/requirements.txt`](bin/requirements.txt) | Optional `tiktoken` for accurate `cl100k_base` token measurements. |
 | [`hooks/`](hooks/) | Source assets installed by `install-hooks` (Claude `session-start.sh` / `user-prompt-submit.sh`, Copilot reinforcement block, Cursor `.mdc` rule). |
 | [`commands/`](commands/) | Source assets installed by `install-commands` (Claude `compress.md` / `restore.md`, Copilot `*.prompt.md`, Cursor `*.md`). |
-| [`post-install.flags`](post-install.flags) | Declarative wizard hooks so `./wizard.sh --caveman --caveman-hooks` / `--caveman-commands` run their installers after deploy without editing `wizard.sh`. |
+| [`statusline/`](statusline/) | Source asset installed by `install-statusline` (`caveman-statusline.sh`). |
+| [`post-install.flags`](post-install.flags) | Declarative wizard hooks so `./wizard.sh --caveman --caveman-hooks` / `--caveman-commands` / `--caveman-statusline` run their installers after deploy without editing `wizard.sh`. |
 | [`evals/`](evals/) | Token-reduction evaluation harness (`run.sh` regenerates `RESULTS.md`). |
-| [`tests/`](tests/) | Bats coverage for the role, the compressor, the installers and the wizard's `--caveman` / `--caveman-hooks` / `--caveman-commands` flags. |
+| [`tests/`](tests/) | Bats coverage for the role, the compressor, the installers and the wizard's `--caveman` / `--caveman-hooks` / `--caveman-commands` / `--caveman-statusline` flags. |
 
 The user-facing chapter for caveman lives in
 [`docs/11-caveman-mode.md`](../../docs/11-caveman-mode.md) (kept at its
@@ -98,6 +100,38 @@ modules/caveman/bin/install-commands uninstall
 Each shipped file carries a `<!-- caveman:command -->` sentinel; the
 uninstaller only removes files that still carry it, so user-authored
 files in the same directory are never touched.
+
+## How to enable the statusline (issue #60, Claude Code only)
+
+Claude Code is the only platform that exposes a statusline API today,
+so this is intentionally Claude-only. The statusline reports cumulative
+compression savings across the workspace by walking every
+`*.original.md` backup left by the compressor and comparing its size
+against the live counterpart.
+
+```bash
+./wizard.sh --caveman --caveman-statusline    # opt in at deploy time
+# or, on an existing deployment:
+modules/caveman/bin/install-statusline install
+```
+
+What you see in the Claude Code prompt area:
+
+```text
+caveman: ready                                  # no backups yet
+caveman: 3 files | -1234 bytes (-23%)           # cumulative savings
+```
+
+To remove it:
+
+```bash
+modules/caveman/bin/install-statusline uninstall
+```
+
+The `statusLine` entry in `.claude/settings.json` is tagged with
+`__caveman: true`, so the uninstaller only clears the field if it is
+still owned by caveman — a statusline installed by another tool is left
+untouched.
 
 ## How to remove the module entirely
 

--- a/modules/caveman/bin/install-statusline
+++ b/modules/caveman/bin/install-statusline
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# install-statusline — wire (or remove) the caveman statusline in
+# Claude Code's .claude/settings.json.
+#
+# Claude Code is the only platform that exposes a statusline API today,
+# so this installer is intentionally Claude-only. Copilot and Cursor
+# have no equivalent surface; if either gains one in the future, add a
+# branch here following the install-hooks / install-commands pattern.
+#
+# USAGE
+#   modules/caveman/bin/install-statusline install   [options]
+#   modules/caveman/bin/install-statusline uninstall [options]
+#
+# OPTIONS
+#   --target  PATH      Project root to install into. Default: cwd.
+#   -h, --help          Show this help.
+#
+# WHAT IT DOES
+#   install   - copies caveman-statusline.sh under
+#               .claude/statusline/caveman-statusline.sh (executable)
+#               and points settings.json's `statusLine` field at it,
+#               tagged with "__caveman": true so uninstall is precise.
+#   uninstall - removes the script and clears the `statusLine` field,
+#               but only if it carries the caveman marker. A statusline
+#               installed by another tool is left untouched.
+#
+# EXIT CODES
+#   0  success
+#   1  usage error / target missing
+#   2  python3 missing while needed for JSON merge
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_DIR="$(cd "${HERE}/.." && pwd)"
+STATUSLINE_SRC="${MODULE_DIR}/statusline/caveman-statusline.sh"
+
+ACTION=""
+TARGET="$(pwd)"
+
+die() { printf 'install-statusline: error: %s\n' "$*" >&2; exit 1; }
+note() { printf '[install-statusline] %s\n' "$*"; }
+
+usage() {
+    sed -n '2,/^set -euo/p' "${BASH_SOURCE[0]}" | sed -e 's/^# \{0,1\}//' -e '$d'
+}
+
+# JSON merge / unmerge of the statusLine field. Mirrors the helper in
+# install-hooks: tag our entry with "__caveman" so uninstall only
+# removes what we own.
+claude_settings_apply() {
+    local action="$1" settings_path="$2"
+    command -v python3 >/dev/null 2>&1 \
+        || { printf 'install-statusline: error: python3 is required to update %s\n' "$settings_path" >&2; exit 2; }
+
+    mkdir -p "$(dirname "$settings_path")"
+    [[ -f "$settings_path" ]] || printf '{}\n' > "$settings_path"
+
+    SETTINGS_PATH="$settings_path" \
+    ACTION="$action" \
+    python3 - <<'PY'
+import json, os, sys
+
+path = os.environ["SETTINGS_PATH"]
+action = os.environ["ACTION"]
+
+with open(path, "r", encoding="utf-8") as fh:
+    try:
+        data = json.load(fh)
+    except json.JSONDecodeError:
+        data = {}
+
+existing = data.get("statusLine")
+
+if action == "install":
+    data["statusLine"] = {
+        "type": "command",
+        "command": ".claude/statusline/caveman-statusline.sh",
+        "__caveman": True,
+    }
+else:  # uninstall
+    if isinstance(existing, dict) and existing.get("__caveman"):
+        del data["statusLine"]
+    # Otherwise: leave it alone — not ours.
+
+with open(path, "w", encoding="utf-8") as fh:
+    json.dump(data, fh, indent=2, sort_keys=False)
+    fh.write("\n")
+PY
+}
+
+# ── Argument parsing ────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        install|uninstall)   ACTION="$1"; shift ;;
+        --target)            TARGET="${2:?--target requires a value}"; shift 2 ;;
+        -h|--help)           usage; exit 0 ;;
+        *)                   die "unknown argument: $1" ;;
+    esac
+done
+
+[[ -n "$ACTION" ]]               || die "missing action (install|uninstall)"
+[[ -d "$TARGET" ]]               || die "target directory does not exist: $TARGET"
+
+TARGET="$(cd "$TARGET" && pwd)"
+[[ -d "${TARGET}/.claude" ]]     || die "no Claude Code deployment found under $TARGET (need .claude/)"
+
+settings="${TARGET}/.claude/settings.json"
+script_dest="${TARGET}/.claude/statusline/caveman-statusline.sh"
+
+if [[ "$ACTION" == "install" ]]; then
+    [[ -f "$STATUSLINE_SRC" ]] || die "missing source script: $STATUSLINE_SRC"
+    install -m 0755 -D "$STATUSLINE_SRC" "$script_dest"
+    claude_settings_apply install "$settings"
+    note "Claude statusline installed at .claude/statusline/caveman-statusline.sh"
+else
+    claude_settings_apply uninstall "$settings"
+    rm -f "$script_dest"
+    rmdir "${TARGET}/.claude/statusline" 2>/dev/null || true
+    note "Claude statusline removed"
+fi
+
+note "Done."

--- a/modules/caveman/post-install.flags
+++ b/modules/caveman/post-install.flags
@@ -11,3 +11,4 @@
 # automation alongside a module without editing wizard.sh.
 --caveman-hooks	bin/install-hooks install --mode remind --target {TARGET}	Install caveman reinforcement hooks (Claude SessionStart + Copilot/Cursor reminder).
 --caveman-commands	bin/install-commands install --target {TARGET}	Install caveman slash commands: /compress and /restore for Claude, Copilot and Cursor.
+--caveman-statusline	bin/install-statusline install --target {TARGET}	Install caveman compression-savings statusline (Claude Code only).

--- a/modules/caveman/statusline/caveman-statusline.sh
+++ b/modules/caveman/statusline/caveman-statusline.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# caveman-statusline — Claude Code statusline that reports compression
+# savings across the workspace.
+#
+# Claude Code invokes statusline scripts on every turn (rate-limited to
+# ~300ms). It pipes a JSON payload on stdin (session_id, transcript_path,
+# cwd, model, ...) and prints whatever this script writes on stdout as
+# the statusline. Stderr and exit codes are ignored.
+#
+# Contract:
+# - Must be fast (<300ms). We rely on `find` + `stat` only.
+# - Must never modify any file. Read-only.
+# - Must never abort. Errors fall back to a neutral "caveman: ready"
+#   line so the user is not left without a statusline.
+#
+# Output:
+#   "caveman: ready"                                 — no compressed files
+#   "caveman: N file(s) | -X bytes (-Y%)"            — savings detected
+set -uo pipefail
+
+# Be defensive about CWD: Claude passes cwd in the JSON, but $PWD is
+# typically the same. Don't bother parsing JSON for portability.
+ROOT="${PWD:-.}"
+
+# Find all .original.md backup files anywhere in the workspace, prune
+# heavy / irrelevant trees.
+mapfile -t backups < <(
+    find "$ROOT" \
+        \( -name node_modules -o -name .git -o -name dist -o -name build -o -name .venv -o -name venv -o -name target \) -prune -o \
+        -type f -name '*.original.md' -print 2>/dev/null
+)
+
+if (( ${#backups[@]} == 0 )); then
+    printf 'caveman: ready'
+    exit 0
+fi
+
+count=0
+orig_total=0
+live_total=0
+
+for orig in "${backups[@]}"; do
+    # Live counterpart: drop the ".original" infix.
+    live="${orig%.original.md}.md"
+    [[ -f "$live" ]] || continue
+
+    # `stat -c %s` (GNU) and `stat -f %z` (BSD/macOS). Try both.
+    obytes="$(stat -c %s -- "$orig" 2>/dev/null || stat -f %z -- "$orig" 2>/dev/null || echo 0)"
+    lbytes="$(stat -c %s -- "$live" 2>/dev/null || stat -f %z -- "$live" 2>/dev/null || echo 0)"
+
+    # Skip pathological reads.
+    [[ "$obytes" =~ ^[0-9]+$ ]] || continue
+    [[ "$lbytes" =~ ^[0-9]+$ ]] || continue
+
+    count=$((count + 1))
+    orig_total=$((orig_total + obytes))
+    live_total=$((live_total + lbytes))
+done
+
+if (( count == 0 || orig_total == 0 )); then
+    printf 'caveman: ready'
+    exit 0
+fi
+
+# Negative delta = compression win; positive would mean the "compressed"
+# file grew (rare but possible if the user re-edited it).
+delta=$((live_total - orig_total))
+pct=$(( delta * 100 / orig_total ))
+
+printf 'caveman: %d file%s | %+d bytes (%+d%%)' \
+    "$count" \
+    "$([[ $count -eq 1 ]] && printf '' || printf 's')" \
+    "$delta" \
+    "$pct"

--- a/modules/caveman/tests/statusline.bats
+++ b/modules/caveman/tests/statusline.bats
@@ -1,0 +1,134 @@
+#!/usr/bin/env bats
+# Tests for modules/caveman/bin/install-statusline. Statusline is
+# Claude-only; no Copilot/Cursor branches to test.
+
+load '../../../tests/lib/helpers'
+
+INSTALL_STATUSLINE="${BATS_TEST_DIRNAME}/../bin/install-statusline"
+STATUSLINE_SH="${BATS_TEST_DIRNAME}/../statusline/caveman-statusline.sh"
+
+setup() {
+    setup_tmp
+    cd "$TEST_TMP"
+    mkdir -p .claude
+    printf '{}\n' > .claude/settings.json
+}
+
+teardown() { teardown_tmp; }
+
+# ── Installer ────────────────────────────────────────────────────────
+
+@test "install-statusline --help returns 0 and mentions install/uninstall" {
+    run "$INSTALL_STATUSLINE" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"install"* ]]
+    [[ "$output" == *"uninstall"* ]]
+}
+
+@test "install-statusline aborts when .claude/ is missing" {
+    rm -rf .claude
+    run "$INSTALL_STATUSLINE" install
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"no Claude Code deployment found"* ]]
+}
+
+@test "install copies the script and points settings.json at it" {
+    run "$INSTALL_STATUSLINE" install
+    [ "$status" -eq 0 ]
+    [ -x .claude/statusline/caveman-statusline.sh ]
+    run python3 -c 'import json,sys; d=json.load(open(".claude/settings.json")); s=d["statusLine"]; sys.exit(0 if s.get("__caveman") and s.get("command")==".claude/statusline/caveman-statusline.sh" else 1)'
+    [ "$status" -eq 0 ]
+}
+
+@test "install is idempotent (reinstall does not duplicate the entry)" {
+    "$INSTALL_STATUSLINE" install
+    "$INSTALL_STATUSLINE" install
+    # statusLine is a single object, so "duplication" would surface as
+    # an array or as a stale non-caveman entry. Confirm the marker is
+    # still present and the field is still an object.
+    run python3 -c 'import json,sys; d=json.load(open(".claude/settings.json")); s=d["statusLine"]; sys.exit(0 if isinstance(s, dict) and s.get("__caveman") else 1)'
+    [ "$status" -eq 0 ]
+}
+
+@test "uninstall removes the script and clears the field" {
+    "$INSTALL_STATUSLINE" install
+    run "$INSTALL_STATUSLINE" uninstall
+    [ "$status" -eq 0 ]
+    [ ! -e .claude/statusline/caveman-statusline.sh ]
+    run python3 -c 'import json,sys; d=json.load(open(".claude/settings.json")); sys.exit(0 if "statusLine" not in d else 1)'
+    [ "$status" -eq 0 ]
+}
+
+@test "uninstall preserves a foreign statusline (no caveman marker)" {
+    python3 -c 'import json; json.dump({"statusLine": {"type":"command","command":"my-tool"}}, open(".claude/settings.json","w"))'
+    run "$INSTALL_STATUSLINE" uninstall
+    [ "$status" -eq 0 ]
+    run python3 -c 'import json,sys; d=json.load(open(".claude/settings.json")); s=d.get("statusLine") or {}; sys.exit(0 if s.get("command")=="my-tool" else 1)'
+    [ "$status" -eq 0 ]
+}
+
+# ── Statusline script ───────────────────────────────────────────────
+
+@test "statusline prints 'caveman: ready' on a workspace with no backups" {
+    run bash "$STATUSLINE_SH" <<<'{}'
+    [ "$status" -eq 0 ]
+    [[ "$output" == "caveman: ready" ]]
+}
+
+@test "statusline reports byte savings when .original.md is larger than .md" {
+    printf 'This is a long original prose with many many filler words.\n' > doc.original.md
+    printf 'Short.\n' > doc.md
+    run bash "$STATUSLINE_SH" <<<'{}'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"caveman: 1 file"* ]]
+    [[ "$output" == *"-"*"bytes"* ]]
+    [[ "$output" == *"%"* ]]
+}
+
+@test "statusline counts multiple files and aggregates savings" {
+    printf 'AAAAAAAAAAAAAAAAAAAA\n' > a.original.md
+    printf 'A\n' > a.md
+    printf 'BBBBBBBBBBBBBBBBBBBB\n' > b.original.md
+    printf 'B\n' > b.md
+    run bash "$STATUSLINE_SH" <<<'{}'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"caveman: 2 files"* ]]
+}
+
+@test "statusline ignores backup files whose live counterpart is missing" {
+    printf 'AAAAAAAAAAAAAAAAAAAA\n' > orphan.original.md
+    run bash "$STATUSLINE_SH" <<<'{}'
+    [ "$status" -eq 0 ]
+    [[ "$output" == "caveman: ready" ]]
+}
+
+@test "statusline never aborts on a malformed JSON payload" {
+    run bash "$STATUSLINE_SH" <<<'this is not json at all'
+    [ "$status" -eq 0 ]
+}
+
+# ── Wizard wiring ───────────────────────────────────────────────────
+
+@test "wizard --help lists --caveman-statusline" {
+    run "$WIZARD" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--caveman-statusline"* ]]
+}
+
+@test "discover_modules registers the --caveman-statusline post-install flag" {
+    source_wizard_functions
+    run postinstall_index_by_flag --caveman-statusline
+    [ "$status" -eq 0 ]
+}
+
+@test "post-install action is skipped if caveman module is not included" {
+    source_wizard_functions
+    local idx
+    idx="$(postinstall_index_by_flag --caveman-statusline)"
+    POSTINSTALL_REQUESTED[$idx]=true
+    module_set_included caveman false
+    TARGET_DIR="$TEST_TMP"
+    run run_postinstall_actions
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Skipping --caveman-statusline"* ]]
+}


### PR DESCRIPTION
## Description

Adds an opt-in **Claude Code statusline** that reports cumulative caveman compression savings across the workspace. Today users have to mentally aggregate savings from each `understudy-compress` run; the statusline surfaces that signal continuously in the prompt area.

Statusline is intentionally **Claude-only** — Copilot and Cursor do not expose a statusline API. This matches the explicit out-of-scope note in #60.

The installer follows the same sidecar pattern shipped in #59 / #61: a `bin/` script and one extra line in `modules/caveman/post-install.flags`, so wizard wiring needed **zero edits to `wizard.sh`**.

Closes #60.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only

## What changes?

**New: `modules/caveman/statusline/caveman-statusline.sh`** — read-only Bash script Claude invokes on every turn. Walks every `*.original.md` backup, compares its size against the live `.md`, and prints:

```text
caveman: ready                                  # no backups yet
caveman: 3 files | -1234 bytes (-23%)           # cumulative savings
```

Defensive by construction:
- Exits 0 in every branch — the statusline never disappears on error.
- Prunes `node_modules`, `.git`, `dist`, `build`, `.venv`, `venv`, `target` to stay under Claude's ~300ms budget.
- Skips backups whose live counterpart was deleted.
- Portable across GNU and BSD `stat`.
- Never reads stdin beyond ignoring it; tolerates malformed JSON payloads.

**New: `modules/caveman/bin/install-statusline`** — `install` / `uninstall` with `--target PATH`. Copies the script to `.claude/statusline/caveman-statusline.sh` (executable) and merges a `statusLine` entry into `.claude/settings.json` tagged `__caveman: true`. Uninstall only clears the field if it is still owned by caveman, so a statusline installed by another tool is left untouched (verified by a test).

**Wizard wiring:** `--caveman-statusline` registered by appending one line to `modules/caveman/post-install.flags`. No edits to `wizard.sh`.

**Docs:** `modules/caveman/README.md` (new "How to enable the statusline" section + ships table updated), `docs/11-caveman-mode.md` (new "Statusline (issue #60, Claude only)" chapter; the "Not shipped" table flips #60 to **Shipped**), `CHANGELOG.md` (`[Unreleased] → Added`).

## How to test

```bash
# Unit/installer tests for the statusline (14 cases)
bats modules/caveman/tests/statusline.bats

# Full suite (251 ok, 0 fail)
./run_tests.sh
```

End-to-end smoke in a temporary directory:

```bash
mkdir /tmp/cv-sl-smoke && cd /tmp/cv-sl-smoke
"$OLDPWD/wizard.sh" --here --yes --caveman --caveman-statusline   # answer 'n' to git init
jq '.statusLine' .claude/settings.json
# → { "type":"command", "command":".claude/statusline/...", "__caveman": true }

# Simulate a compressed file and run the statusline directly
printf 'long original prose with filler words filler words filler\n' > doc.original.md
printf 'short.\n' > doc.md
echo '{}' | bash .claude/statusline/caveman-statusline.sh
# → caveman: 1 file | -53 bytes (-87%)

# Foreign statusline is preserved on uninstall
jq '.statusLine = {"type":"command","command":"my-tool"}' .claude/settings.json | sponge .claude/settings.json
"$OLDPWD/modules/caveman/bin/install-statusline" uninstall
jq '.statusLine.command' .claude/settings.json   # → "my-tool"
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] CHANGELOG.md updated under `[Unreleased]`
