### PR TITLE
release: v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-04-30
+
 ### Added
 
 - **Caveman compression-savings statusline** (closes #60):


### PR DESCRIPTION
## Description

Cuts **v0.8.0**, promoting every caveman roadmap item we shipped under `[Unreleased]` into a tagged release. The CHANGELOG entry is unchanged in content; this PR only adds the version header and a fresh empty `[Unreleased]` block on top.

The release closes the four caveman issues that were tracked from #49:

- #59 — reinforcement hooks (Claude real, Copilot/Cursor degraded)
- #60 — Claude Code compression-savings statusline
- #61 — platform-native slash commands (`/compress`, `/restore`)
- #67 — modular `modules/<name>/` layout, with declarative `post-install.flags` so opt-in automation no longer touches `wizard.sh`

The "Not shipped" table in `docs/11-caveman-mode.md` is now down to a single intentionally-skipped item (`wenyan`, out of scope for an English-language ops tool).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation only

## What changes?

`CHANGELOG.md`: replace the `## [Unreleased]` heading with the existing content moved under a new `## [0.8.0] - 2026-04-30` heading, and re-open an empty `[Unreleased]` block on top. No code changes — the version is read at runtime from this file via `wizard.sh::read_local_version`.

## How to test

```bash
# Version lookup picks up the new release header
./wizard.sh --version 2>&1 || head -10 CHANGELOG.md

# Full suite is the same as on main; no code touched
./run_tests.sh
```

After merge:

```bash
git tag v0.8.0
git push origin v0.8.0
gh release create v0.8.0 --target main --title "v0.8.0" --notes-from-tag
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] CHANGELOG.md updated under `[Unreleased]`
