### PR TITLE
ci: smoke-test release tarball before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,46 @@ jobs:
           tar tzf "$archive" | sort
           echo "Total entries: $(tar tzf "$archive" | wc -l)"
 
+      - name: Smoke-test release tarball
+        run: |
+          archive="${{ steps.tarball.outputs.archive }}"
+          smoke=$(mktemp -d)
+
+          # Extract flat (matches install.sh: `tar xz --strip-components=0`).
+          tar -xzf "$archive" -C "$smoke"
+
+          # Required top-level entries — these are what install.sh expects.
+          required=(wizard.sh install.sh README.md CHANGELOG.md LICENSE understudy.yaml roles templates)
+          missing=0
+          for entry in "${required[@]}"; do
+            if [[ ! -e "$smoke/$entry" ]]; then
+              echo "::error::Release tarball is missing required entry: $entry"
+              missing=1
+            fi
+          done
+
+          # Dev-only paths must NOT ship in the tarball (export-ignore in .gitattributes).
+          forbidden=(.github tests run_tests.sh CONTRIBUTING.md)
+          for entry in "${forbidden[@]}"; do
+            if [[ -e "$smoke/$entry" ]]; then
+              echo "::error::Release tarball must not contain dev-only path: $entry"
+              missing=1
+            fi
+          done
+
+          if [[ $missing -ne 0 ]]; then
+            exit 1
+          fi
+
+          # The wizard must at minimum print --help cleanly from the extracted tree.
+          chmod +x "$smoke/wizard.sh"
+          if ! UNDERSTUDY_SKIP_UPDATE_CHECK=1 bash "$smoke/wizard.sh" --help >/dev/null; then
+            echo "::error::wizard.sh --help failed when run from the extracted tarball"
+            exit 1
+          fi
+
+          echo "Release tarball smoke test passed."
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Description

Adds a smoke-test step to `release.yml` that runs **before** publishing the GitHub Release. The step extracts the freshly built `understudy-vX.Y.Z.tar.gz`, asserts the required runtime entries are present, asserts dev-only paths (gated by `.gitattributes` `export-ignore`) did **not** leak in, and runs `wizard.sh --help` from the extracted tree. If any check fails, the release aborts before the artifact is uploaded.

This protects the install one-liner (`curl … install.sh | bash`) from a bad tarball ever landing on `releases/`.

## Type of change

- [x] chore / CI

## What changes?

- `.github/workflows/release.yml`: new step **Smoke-test release tarball** between `Show tarball contents` and `Create GitHub Release`. The step:
  - Extracts the tarball flat (matches what `install.sh` does with `--strip-components=0`).
  - Verifies required entries: `wizard.sh`, `install.sh`, `README.md`, `CHANGELOG.md`, `LICENSE`, `understudy.yaml`, `roles/`, `templates/`.
  - Verifies forbidden entries are absent: `.github/`, `tests/`, `run_tests.sh`, `CONTRIBUTING.md` (these are `export-ignore`'d in `.gitattributes`).
  - Runs `UNDERSTUDY_SKIP_UPDATE_CHECK=1 bash wizard.sh --help` from the extracted tree.
  - Aborts the release on any failure.

No production code, no docs and no tests changed — the new check only runs on tag pushes via `release.yml`.

## How to test

Locally, against the current `HEAD`:

```bash
archive=$(mktemp -u --suffix=.tar.gz)
git archive --format=tar.gz --worktree-attributes -o "$archive" HEAD
smoke=$(mktemp -d) && tar -xzf "$archive" -C "$smoke"
ls -1 "$smoke"
chmod +x "$smoke/wizard.sh"
UNDERSTUDY_SKIP_UPDATE_CHECK=1 bash "$smoke/wizard.sh" --help >/dev/null && echo OK
```

Should list the 8 required entries (no `.github/`, no `tests/`, no `run_tests.sh`, no `CONTRIBUTING.md`) and print `OK`.

## Checklist

- [x] Code follows the project's style and conventions
- [x] No production code touched (workflow YAML only)
- [x] Tested locally — `git archive` output matches expectations and `wizard.sh --help` runs from the extracted tree
- [x] Bash syntax verified (`bash -n` not applicable to YAML, but the inline shell script was hand-reviewed)
- [x] No new dependencies
