### PR TITLE
feat: add /understudy slash command across all platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,8 @@ understudy/
 │   │       ├── start-session.prompt.md
 │   │       ├── end-session.prompt.md
 │   │       ├── design-feature.prompt.md
-│   │       └── security-review.prompt.md
+│   │       ├── security-review.prompt.md
+│   │       └── understudy.prompt.md
 │   ├── .claude/                 # Claude Code
 │   │   ├── agents/
 │   │   │   ├── architect.md, backend.md, frontend.md
@@ -237,6 +238,7 @@ understudy/
 │   │   ├── commands/
 │   │   │   ├── start-session.md, end-session.md
 │   │   │   ├── design-feature.md, security-review.md
+│   │   │   ├── understudy.md
 │   │   ├── hooks/
 │   │   │   └── guardrails-check.sh
 │   │   └── settings.json
@@ -244,6 +246,8 @@ understudy/
 │   │   ├── agents/
 │   │   │   ├── architect.md, backend.md, frontend.md
 │   │   │   ├── devops.md, security.md, qa-engineer.md
+│   │   ├── commands/
+│   │   │   └── understudy.md
 │   │   └── rules/
 │   │       ├── understudy-global.mdc
 │   │       └── guardrails.mdc

--- a/docs/platforms/claude-code.md
+++ b/docs/platforms/claude-code.md
@@ -63,6 +63,7 @@ claude
 | `/project:end-session` | Update `docs/session-log.md` with today's work |
 | `/project:design-feature` | Architect-driven design with ADR |
 | `/project:security-review` | Focused security review of current changes |
+| `/project:understudy` | Explain understudy capabilities, roles, commands and workflow |
 
 Plus Claude's native commands: `/model`, `/compact`, `/agents` (list), etc.
 
@@ -111,7 +112,10 @@ editing the script.
 # 1) Load context
 /project:start-session
 
-# 2) Design
+# 2) Not sure what's available? Ask understudy
+/project:understudy
+
+# 3) Design
 /project:design-feature
 → Claude asks about the feature, proposes alternatives, adds an ADR.
 

--- a/docs/platforms/cursor.md
+++ b/docs/platforms/cursor.md
@@ -122,11 +122,18 @@ globs: "src/components/**/*.tsx"
 
 It will auto-attach when you edit matching files.
 
+## Commands
+
+The wizard deploys commands under `.cursor/commands/`:
+
+| Command | Purpose |
+|---|---|
+| `understudy.md` | Explains understudy capabilities, available roles, commands and recommended workflow |
+
+Invoke them from Cursor's command palette or chat.
+
 ## Tips specific to Cursor
 
-- Cursor has no slash-command system — for repeatable flows, create rules
-  that describe the procedure (e.g. a "release checklist" rule the agent
-  reads).
 - You can combine agents: switch between architect → backend → security
   without losing the docs/ context.
 - `alwaysApply: true` is powerful but costs tokens — keep those rules

--- a/docs/platforms/vscode-copilot.md
+++ b/docs/platforms/vscode-copilot.md
@@ -60,7 +60,7 @@ Guardrails are always active because they use `applyTo: "**"`.
 
 ## Prompt files
 
-The wizard deploys four ready-to-use prompts under `.github/prompts/`:
+The wizard deploys five ready-to-use prompts under `.github/prompts/`:
 
 | Prompt | Purpose |
 |---|---|
@@ -68,6 +68,7 @@ The wizard deploys four ready-to-use prompts under `.github/prompts/`:
 | `end-session.prompt.md` | Updates `session-log.md` with today's work, decisions and pending items |
 | `design-feature.prompt.md` | Runs the Architect's 8-step design process and writes an ADR |
 | `security-review.prompt.md` | Performs a focused security review of recent changes |
+| `understudy.prompt.md` | Explains understudy capabilities, available roles, commands and recommended workflow |
 
 In Copilot Chat, start typing `/` or the prompt name and VS Code will offer
 them as attachments. You can also right-click a prompt file and run it.

--- a/templates/.claude/commands/understudy.md
+++ b/templates/.claude/commands/understudy.md
@@ -1,0 +1,96 @@
+---
+name: understudy
+description: "Explain what understudy is, its capabilities, available roles, commands, and how to use the team"
+---
+
+You are in a project configured with **understudy** — a system that turns
+a single AI assistant into a complete development team with specialized
+roles, guardrails, and persistent cross-session memory.
+
+Read the following files (skip any that don't exist) and then answer the
+user's question about what understudy provides and how to use it:
+
+1. `AGENTS.md` — team definition and role assignments
+2. `docs/team-roster.md` — active team members
+3. `understudy.yaml` — project configuration (platforms, models, roles)
+
+Then provide the following overview:
+
+## What is understudy?
+
+Understudy deploys AI team configurations for GitHub Copilot, Claude Code,
+and Cursor. Each agent has a defined role, guardrails, and context.
+
+## Available roles
+
+### Core roles (always deployed)
+| Role | Focus |
+|------|-------|
+| **Architect** | System design, APIs, databases, trade-offs, ADRs |
+| **Backend** | Services, business logic, data contracts |
+| **Frontend** | UI, accessibility, UX, state management |
+| **DevOps** | CI/CD, containers, IaC, cloud, deploys |
+| **Security** | Threat modeling, input validation, secrets, OWASP |
+| **QA Engineer** | Test plans, unit/integration/E2E, quality gates |
+
+### Optional roles (add with `--add-member`)
+| Role | Focus |
+|------|-------|
+| **Data Engineer** | ETL/ELT, warehouses, streaming, data governance |
+| **Git Specialist** | Git workflows, branch policies, PR hygiene |
+| **ML Engineer** | ML models, MLOps, LLMs, RAG |
+| **Mobile Engineer** | iOS/Android, React Native, Flutter |
+| **Repo Documenter** | Codebase docs, architecture, onboarding |
+| **Shell Scripting** | Bash/sh automation, cross-platform scripts |
+| **SRE** | SLOs, observability, incident response |
+| **Tech Writer** | API docs, tutorials, Diataxis framework |
+
+## Available slash commands
+
+| Command | What it does |
+|---------|-------------|
+| `/start-session` | Load project context (session log, spec, decisions) |
+| `/end-session` | Summarize work done and update session log |
+| `/design-feature` | Architect a new feature with the Architect role |
+| `/security-review` | Run a security review on a file or component |
+| `/understudy` | This command — explain capabilities |
+
+If **caveman mode** is enabled, also:
+
+| Command | What it does |
+|---------|-------------|
+| `/compress` | Compress a Markdown file to save tokens |
+| `/restore` | Restore a compressed file from backup |
+
+## Persistent memory (cross-session)
+
+| File | Purpose |
+|------|---------|
+| `docs/spec.md` | Living project requirements |
+| `docs/decisions.md` | Architectural Decision Records |
+| `docs/session-log.md` | What was done and what's pending |
+| `docs/team-roster.md` | Active team members and roles |
+
+## Recommended workflow
+
+1. **Start** — `/start-session` to load context
+2. **Spec first** — Write requirements in `docs/spec.md`
+3. **Design** — Architect designs, Security reviews threats
+4. **Build** — Backend + Frontend implement in parallel
+5. **Test** — QA writes and runs tests
+6. **Deploy** — DevOps handles infra and CI/CD
+7. **End** — `/end-session` to save progress
+
+## Configuration
+
+Project settings live in `understudy.yaml`. You can customize:
+- Which platforms to deploy (copilot, claude, cursor)
+- Model assignments per role
+- Guardrails mode (split vs embedded)
+- Session auto-read and auto-update behavior
+
+---
+
+If the user asked a specific question (`$ARGUMENTS`), answer it based on
+the context above. If they just invoked `/understudy` without a question,
+present the full overview.

--- a/templates/.cursor/commands/understudy.md
+++ b/templates/.cursor/commands/understudy.md
@@ -1,0 +1,96 @@
+---
+name: understudy
+description: "Explain what understudy is, its capabilities, available roles, commands, and how to use the team"
+---
+
+You are in a project configured with **understudy** — a system that turns
+a single AI assistant into a complete development team with specialized
+roles, guardrails, and persistent cross-session memory.
+
+Read the following files (skip any that don't exist) and then answer the
+user's question about what understudy provides and how to use it:
+
+1. `AGENTS.md` — team definition and role assignments
+2. `docs/team-roster.md` — active team members
+3. `understudy.yaml` — project configuration (platforms, models, roles)
+
+Then provide the following overview:
+
+## What is understudy?
+
+Understudy deploys AI team configurations for GitHub Copilot, Claude Code,
+and Cursor. Each agent has a defined role, guardrails, and context.
+
+## Available roles
+
+### Core roles (always deployed)
+| Role | Focus |
+|------|-------|
+| **Architect** | System design, APIs, databases, trade-offs, ADRs |
+| **Backend** | Services, business logic, data contracts |
+| **Frontend** | UI, accessibility, UX, state management |
+| **DevOps** | CI/CD, containers, IaC, cloud, deploys |
+| **Security** | Threat modeling, input validation, secrets, OWASP |
+| **QA Engineer** | Test plans, unit/integration/E2E, quality gates |
+
+### Optional roles (add with `--add-member`)
+| Role | Focus |
+|------|-------|
+| **Data Engineer** | ETL/ELT, warehouses, streaming, data governance |
+| **Git Specialist** | Git workflows, branch policies, PR hygiene |
+| **ML Engineer** | ML models, MLOps, LLMs, RAG |
+| **Mobile Engineer** | iOS/Android, React Native, Flutter |
+| **Repo Documenter** | Codebase docs, architecture, onboarding |
+| **Shell Scripting** | Bash/sh automation, cross-platform scripts |
+| **SRE** | SLOs, observability, incident response |
+| **Tech Writer** | API docs, tutorials, Diataxis framework |
+
+## Available slash commands
+
+| Command | What it does |
+|---------|-------------|
+| `/start-session` | Load project context (session log, spec, decisions) |
+| `/end-session` | Summarize work done and update session log |
+| `/design-feature` | Architect a new feature with the Architect role |
+| `/security-review` | Run a security review on a file or component |
+| `/understudy` | This command — explain capabilities |
+
+If **caveman mode** is enabled, also:
+
+| Command | What it does |
+|---------|-------------|
+| `/compress` | Compress a Markdown file to save tokens |
+| `/restore` | Restore a compressed file from backup |
+
+## Persistent memory (cross-session)
+
+| File | Purpose |
+|------|---------|
+| `docs/spec.md` | Living project requirements |
+| `docs/decisions.md` | Architectural Decision Records |
+| `docs/session-log.md` | What was done and what's pending |
+| `docs/team-roster.md` | Active team members and roles |
+
+## Recommended workflow
+
+1. **Start** — `/start-session` to load context
+2. **Spec first** — Write requirements in `docs/spec.md`
+3. **Design** — Architect designs, Security reviews threats
+4. **Build** — Backend + Frontend implement in parallel
+5. **Test** — QA writes and runs tests
+6. **Deploy** — DevOps handles infra and CI/CD
+7. **End** — `/end-session` to save progress
+
+## Configuration
+
+Project settings live in `understudy.yaml`. You can customize:
+- Which platforms to deploy (copilot, claude, cursor)
+- Model assignments per role
+- Guardrails mode (split vs embedded)
+- Session auto-read and auto-update behavior
+
+---
+
+If the user asked a specific question, answer it based on the context
+above. If they just invoked `/understudy` without a question, present
+the full overview.

--- a/templates/.github/prompts/understudy.prompt.md
+++ b/templates/.github/prompts/understudy.prompt.md
@@ -1,0 +1,96 @@
+---
+mode: 'agent'
+description: 'Explain what understudy is, its capabilities, available roles, commands, and how to use the team'
+---
+
+You are in a project configured with **understudy** — a system that turns
+a single AI assistant into a complete development team with specialized
+roles, guardrails, and persistent cross-session memory.
+
+Read the following files (skip any that don't exist) and then answer the
+user's question about what understudy provides and how to use it:
+
+1. `AGENTS.md` — team definition and role assignments
+2. `docs/team-roster.md` — active team members
+3. `understudy.yaml` — project configuration (platforms, models, roles)
+
+Then provide the following overview:
+
+## What is understudy?
+
+Understudy deploys AI team configurations for GitHub Copilot, Claude Code,
+and Cursor. Each agent has a defined role, guardrails, and context.
+
+## Available roles
+
+### Core roles (always deployed)
+| Role | Focus |
+|------|-------|
+| **Architect** | System design, APIs, databases, trade-offs, ADRs |
+| **Backend** | Services, business logic, data contracts |
+| **Frontend** | UI, accessibility, UX, state management |
+| **DevOps** | CI/CD, containers, IaC, cloud, deploys |
+| **Security** | Threat modeling, input validation, secrets, OWASP |
+| **QA Engineer** | Test plans, unit/integration/E2E, quality gates |
+
+### Optional roles (add with `--add-member`)
+| Role | Focus |
+|------|-------|
+| **Data Engineer** | ETL/ELT, warehouses, streaming, data governance |
+| **Git Specialist** | Git workflows, branch policies, PR hygiene |
+| **ML Engineer** | ML models, MLOps, LLMs, RAG |
+| **Mobile Engineer** | iOS/Android, React Native, Flutter |
+| **Repo Documenter** | Codebase docs, architecture, onboarding |
+| **Shell Scripting** | Bash/sh automation, cross-platform scripts |
+| **SRE** | SLOs, observability, incident response |
+| **Tech Writer** | API docs, tutorials, Diataxis framework |
+
+## Available slash commands
+
+| Command | What it does |
+|---------|-------------|
+| `/start-session` | Load project context (session log, spec, decisions) |
+| `/end-session` | Summarize work done and update session log |
+| `/design-feature` | Architect a new feature with the Architect role |
+| `/security-review` | Run a security review on a file or component |
+| `/understudy` | This command — explain capabilities |
+
+If **caveman mode** is enabled, also:
+
+| Command | What it does |
+|---------|-------------|
+| `/compress` | Compress a Markdown file to save tokens |
+| `/restore` | Restore a compressed file from backup |
+
+## Persistent memory (cross-session)
+
+| File | Purpose |
+|------|---------|
+| `docs/spec.md` | Living project requirements |
+| `docs/decisions.md` | Architectural Decision Records |
+| `docs/session-log.md` | What was done and what's pending |
+| `docs/team-roster.md` | Active team members and roles |
+
+## Recommended workflow
+
+1. **Start** — `/start-session` to load context
+2. **Spec first** — Write requirements in `docs/spec.md`
+3. **Design** — Architect designs, Security reviews threats
+4. **Build** — Backend + Frontend implement in parallel
+5. **Test** — QA writes and runs tests
+6. **Deploy** — DevOps handles infra and CI/CD
+7. **End** — `/end-session` to save progress
+
+## Configuration
+
+Project settings live in `understudy.yaml`. You can customize:
+- Which platforms to deploy (copilot, claude, cursor)
+- Model assignments per role
+- Guardrails mode (split vs embedded)
+- Session auto-read and auto-update behavior
+
+---
+
+If the user asked a specific question, answer it based on the context
+above. If they just invoked `/understudy` without a question, present
+the full overview.

--- a/tests/integration/deploy_all_platforms.bats
+++ b/tests/integration/deploy_all_platforms.bats
@@ -88,13 +88,14 @@ run_wizard_noninteractive() {
   [ -f "$dir/qa.md" ]
 }
 
-@test "full deploy creates all 4 Claude Code commands" {
+@test "full deploy creates all 5 Claude Code commands" {
   run_wizard_noninteractive "myproject" "$TEST_TMP" "Y" "Y" "Y"
   local dir="$TEST_TMP/myproject/.claude/commands"
   [ -f "$dir/start-session.md" ]
   [ -f "$dir/end-session.md" ]
   [ -f "$dir/design-feature.md" ]
   [ -f "$dir/security-review.md" ]
+  [ -f "$dir/understudy.md" ]
 }
 
 @test "full deploy creates Claude Code settings.json" {
@@ -126,6 +127,11 @@ run_wizard_noninteractive() {
   [ -f "$TEST_TMP/myproject/.cursor/rules/guardrails.mdc" ]
 }
 
+@test "full deploy creates Cursor commands" {
+  run_wizard_noninteractive "myproject" "$TEST_TMP" "Y" "Y" "Y"
+  [ -f "$TEST_TMP/myproject/.cursor/commands/understudy.md" ]
+}
+
 @test "full deploy creates docs/ memory files" {
   run_wizard_noninteractive "myproject" "$TEST_TMP" "Y" "Y" "Y"
   local dir="$TEST_TMP/myproject/docs"
@@ -147,6 +153,7 @@ run_wizard_noninteractive() {
   [ -f "$dir/end-session.prompt.md" ]
   [ -f "$dir/design-feature.prompt.md" ]
   [ -f "$dir/security-review.prompt.md" ]
+  [ -f "$dir/understudy.prompt.md" ]
 }
 
 # ── Placeholder substitution in deployed files ────────────────────────────────

--- a/tests/unit/deploy_gitignore.bats
+++ b/tests/unit/deploy_gitignore.bats
@@ -94,6 +94,7 @@ teardown() { teardown_tmp; }
   PLATFORM_CURSOR=true
   deploy_gitignore
   grep -q ".cursor/agents/" "$TARGET_DIR/.gitignore"
+  grep -q ".cursor/commands/" "$TARGET_DIR/.gitignore"
   grep -q "understudy-global.mdc" "$TARGET_DIR/.gitignore"
   grep -q "guardrails.mdc" "$TARGET_DIR/.gitignore"
 }

--- a/wizard.sh
+++ b/wizard.sh
@@ -464,6 +464,7 @@ validate_claude_templates() {
         ".claude/commands/end-session.md"
         ".claude/commands/design-feature.md"
         ".claude/commands/security-review.md"
+        ".claude/commands/understudy.md"
         ".claude/settings.json"
         ".claude/hooks/guardrails-check.sh"
     )
@@ -485,6 +486,7 @@ validate_cursor_templates() {
         ".cursor/agents/devops.md"
         ".cursor/agents/security.md"
         ".cursor/agents/qa-engineer.md"
+        ".cursor/commands/understudy.md"
         ".cursor/rules/understudy-global.mdc"
         ".cursor/rules/guardrails.mdc"
     )
@@ -1345,6 +1347,7 @@ deploy_cursor() {
     step "Deploying Cursor files"
 
     mkdir -p "${TARGET_DIR}/.cursor/agents"
+    mkdir -p "${TARGET_DIR}/.cursor/commands"
     mkdir -p "${TARGET_DIR}/.cursor/rules"
 
     # Global rules
@@ -1354,6 +1357,13 @@ deploy_cursor() {
     for agent_file in "${TEMPLATES_DIR}/.cursor/agents/"*.md; do
         if [[ -f "$agent_file" ]]; then
             deploy_file "$agent_file" "${TARGET_DIR}/.cursor/agents/$(basename "$agent_file")"
+        fi
+    done
+
+    # Commands
+    for cmd_file in "${TEMPLATES_DIR}/.cursor/commands/"*.md; do
+        if [[ -f "$cmd_file" ]]; then
+            deploy_file "$cmd_file" "${TARGET_DIR}/.cursor/commands/$(basename "$cmd_file")"
         fi
     done
 
@@ -1412,6 +1422,7 @@ deploy_gitignore() {
         if $PLATFORM_CURSOR; then
             {
                 printf '.cursor/agents/\n'
+                printf '.cursor/commands/\n'
                 printf '.cursor/rules/understudy-global.mdc\n'
                 printf '.cursor/rules/guardrails.mdc\n'
             } >> "$gitignore"


### PR DESCRIPTION
## Description

Add a new `/understudy` slash command that acts as an interactive guide to the project's understudy configuration. When invoked, the AI reads the project's `AGENTS.md`, `docs/team-roster.md`, and `understudy.yaml`, then explains available roles, commands, persistent memory files, recommended workflow, and configuration options.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation only
- [ ] Refactor / chore

## What changes?

### New files
- `templates/.github/prompts/understudy.prompt.md` — Copilot slash command
- `templates/.claude/commands/understudy.md` — Claude Code slash command
- `templates/.cursor/commands/understudy.md` — Cursor slash command

### Modified files
- `wizard.sh` — Adds Cursor commands deployment loop (`templates/.cursor/commands/`), `.cursor/commands/` in gitignore, and `understudy.md` to template validation arrays
- `tests/integration/deploy_all_platforms.bats` — Updates Claude commands assertion from 4→5, Copilot prompts from 4→5, adds new Cursor commands test
- `tests/unit/deploy_gitignore.bats` — Adds `.cursor/commands/` gitignore check
- `docs/platforms/claude-code.md` — Adds `/project:understudy` to command table and example workflow
- `docs/platforms/vscode-copilot.md` — Updates from "four" to "five" prompts, adds `understudy.prompt.md` to table
- `docs/platforms/cursor.md` — Adds new "Commands" section (previously stated Cursor had no slash commands)
- `README.md` — Adds `understudy.prompt.md`, `understudy.md`, and `.cursor/commands/` to file tree

## How to test

1. Run `./run_tests.sh` — all unit, hook, and integration tests should pass (caveman module failures are pre-existing due to missing python3 on Windows).
2. Deploy to a test project: `./wizard.sh` with all three platforms enabled.
3. Verify the following files exist:
   - `.github/prompts/understudy.prompt.md`
   - `.claude/commands/understudy.md`
   - `.cursor/commands/understudy.md`
4. In VS Code Copilot Chat, invoke `@workspace /understudy` and verify it shows the capabilities overview.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated the documentation accordingly
- [x] New and existing tests pass locally
- [x] I have added tests that prove my fix/feature works
