### PR TITLE
docs: audit and expand full documentation suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -499,7 +499,7 @@ Key conventions:
 ### Caveman evals harness (opt-in)
 
 The directory [`modules/caveman/evals/`](../modules/caveman/evals/README.md) ships a separate,
-opt-in measurement harness for [caveman mode](../docs/11-caveman-mode.md). It
+opt-in measurement harness for [caveman mode](../docs/10-caveman-mode.md). It
 is **not** wired into `./run_tests.sh` and does not gate CI — it produces
 human-readable token-reduction numbers in `modules/caveman/evals/RESULTS.md`. Run it
 manually after changes to the role, the compress script, or the template

--- a/README.md
+++ b/README.md
@@ -265,6 +265,16 @@ understudy/
 │   ├── shell-scripting.instructions.md
 │   ├── tech-writer.instructions.md
 │   └── sre.instructions.md
+├── modules/                     # 🧩 Opt-in modules
+│   └── caveman/                 # Token-efficient communication
+│       ├── module.yaml          # Module manifest (auto-discovered)
+│       ├── role.instructions.md  # Caveman role definition
+│       ├── bin/                 # understudy-compress, install-hooks, etc.
+│       ├── commands/            # Slash command templates per platform
+│       ├── hooks/               # Reinforcement hook templates
+│       ├── statusline/          # Claude Code statusline script
+│       ├── evals/               # Token-reduction evaluation harness
+│       └── tests/               # Module-specific bats tests
 ├── tests/                       # 🧪 bats test suite
 │   ├── unit/                    # config_read, detect, deploy_file, guardrails
 │   ├── hooks/                   # guardrails-check.sh tests
@@ -276,6 +286,8 @@ understudy/
     ├── 01-introduction.md
     ├── 02-quick-start.md
     ├── 03-platform-comparison.md
+    ├── 04-guardrails.md
+    ├── 05-roles-and-workflow.md
     ├── platforms/
     │   ├── copilot-cli.md
     │   ├── vscode-copilot.md
@@ -283,7 +295,8 @@ understudy/
     │   └── cursor.md
     ├── 08-cross-platform-workflows.md
     ├── 09-configuration.md
-    └── 10-troubleshooting.md
+    ├── 10-caveman-mode.md
+    └── 11-troubleshooting.md
 ```
 
 ## Documentation
@@ -296,13 +309,16 @@ published as a static site without restructuring.
 | [Introduction and Core Concepts](docs/01-introduction.md) | Mental model, agents, spec-driven development, persistent memory, guardrails, roles catalog, generated files |
 | [Quick Start](docs/02-quick-start.md) | Install, first session, extending the team |
 | [Platform Capability Matrix](docs/03-platform-comparison.md) | What each tool supports out of the box |
+| [Guardrails](docs/04-guardrails.md) | 8 categories, deployment modes, enforcement per platform, customization |
+| [Roles & Spec-Driven Development](docs/05-roles-and-workflow.md) | Role system, `applyTo`, spec lifecycle, session protocol, ADRs, sub-agents |
 | [GitHub Copilot CLI](docs/platforms/copilot-cli.md) | Setup, commands, full feature flow, sub-agents, tips |
 | [VS Code Copilot](docs/platforms/vscode-copilot.md) | `applyTo` globs, prompt files, start → work → end flow |
 | [Claude Code](docs/platforms/claude-code.md) | Agents, slash commands, deny list, PreToolUse hook, adding commands |
 | [Cursor](docs/platforms/cursor.md) | Rules (MDC), agent panel, creating your own rules |
 | [Cross-Platform Workflows](docs/08-cross-platform-workflows.md) | Mixed setups and the shared session protocol |
 | [Configuration Reference](docs/09-configuration.md) | Full `understudy.yaml` reference |
-| [Troubleshooting and FAQ](docs/10-troubleshooting.md) | Common issues, model choice, reporting bugs |
+| [Caveman Mode](docs/10-caveman-mode.md) | Token-efficient role, compress script, hooks, statusline, evals |
+| [Troubleshooting and FAQ](docs/11-troubleshooting.md) | Common issues, model choice, reporting bugs |
 
 ## Wizard Commands
 
@@ -404,7 +420,7 @@ The `roles/` folder is the **official optional roles catalog** for the system. T
 
 | Role | When to use it |
 |---|---|
-| 🐉 **caveman** | Token-efficient prose. Drops fillers; keeps code/paths/URLs. Opt-in via `--caveman`. See [Caveman Mode](docs/11-caveman-mode.md). |
+| 🐉 **caveman** | Token-efficient prose. Drops fillers; keeps code/paths/URLs. Opt-in via `--caveman`. See [Caveman Mode](docs/10-caveman-mode.md). |
 | 📊 **data-engineer** | ETL/ELT pipelines, data warehouses, streaming, data governance |
 | 🌿 **git-specialist** | Git workflows, branch policies, PR hygiene, release discipline |
 | 📱 **mobile-engineer** | iOS/Android apps, React Native, Flutter |
@@ -567,5 +583,5 @@ This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md) as its code 
   is inspired by [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman) —
   thanks to its author for the original idea of token-efficient AI prose and for
   open-sourcing the prompt patterns that informed our port. See
-  [docs/11-caveman-mode.md](docs/11-caveman-mode.md) for what we adapted and
+  [docs/10-caveman-mode.md](docs/10-caveman-mode.md) for what we adapted and
   what we intentionally did not ship.

--- a/docs/01-introduction.md
+++ b/docs/01-introduction.md
@@ -113,6 +113,7 @@ your-project/
 │   └── settings.json             # Permissions + hook wiring
 └── .cursor/
     ├── agents/                   # Role agents (Agent panel)
+    ├── commands/                  # Commands (e.g. understudy.md)
     └── rules/                    # Global rules + guardrails (always-on)
 ```
 

--- a/docs/02-quick-start.md
+++ b/docs/02-quick-start.md
@@ -116,7 +116,7 @@ available in every future deployment.
 ## Optional: caveman mode (token-efficient)
 
 If you want shorter, denser AI replies and a smaller context bill, opt into
-[caveman mode](11-caveman-mode.md):
+[caveman mode](10-caveman-mode.md):
 
 ```bash
 understudy --caveman          # add the caveman role at deploy time
@@ -132,7 +132,20 @@ modules/caveman/bin/understudy-compress --restore docs/spec.md
 ```
 
 Full rationale, intensity levels, safety gates and the
-[evals harness](../modules/caveman/evals/README.md) live in chapter 11.
+[evals harness](../modules/caveman/evals/README.md) live in
+[chapter 10](10-caveman-mode.md).
+
+## Uninstall
+
+To remove Understudy from your system:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash -s -- --uninstall
+```
+
+This removes `~/.understudy/` and the `understudy` launcher. It does **not**
+touch files deployed inside your projects — those are yours to keep or remove
+manually.
 
 ## Update Understudy
 

--- a/docs/03-platform-comparison.md
+++ b/docs/03-platform-comparison.md
@@ -44,4 +44,4 @@ Per-platform guides:
 
 ---
 
-Next: [Cross-Platform Workflows](08-cross-platform-workflows.md)
+Next: [Guardrails](04-guardrails.md)

--- a/docs/04-guardrails.md
+++ b/docs/04-guardrails.md
@@ -1,0 +1,199 @@
+# 4. Guardrails
+
+Guardrails are **non-negotiable security and behavior limits** that every
+Understudy agent must respect, without exception. They are not suggestions —
+they are hard restrictions enforced at multiple levels.
+
+## Why guardrails exist
+
+AI assistants are powerful but unpredictable. Without explicit limits, an
+agent might:
+
+- Hardcode a secret in a commit
+- Run `rm -rf /` or `terraform destroy` without thinking twice
+- Process real customer data and echo it back
+- Push directly to production
+- Write code before the spec is agreed
+
+Guardrails prevent all of this. They are deployed automatically by the
+wizard and active from the first session.
+
+## The 8 categories
+
+| # | Category | What it protects |
+|---|---|---|
+| 1 | **Security** | No hardcoded secrets, mandatory input validation, least privilege |
+| 2 | **Scope & Ownership** | Each agent owns specific areas; crossing boundaries requires justification |
+| 3 | **Process (Spec-Driven)** | No code without an approved spec (exceptions: bugfixes, emergencies, CVEs) |
+| 4 | **Destructive Operations** | PM confirmation before deleting, purging or revoking anything |
+| 5 | **Data & PII** | No real data, no PII in code/tests/logs; synthetic data only |
+| 6 | **Quality** | Self-review, appropriate tests, no dead code, explicit error handling |
+| 7 | **Environments** | Promotion order dev → test → acc → eng → prd; mandatory IaC |
+| 8 | **Documentation** | ADRs in `decisions.md`, session log updated, spec kept current |
+
+### 1. Security
+
+- **NEVER** hardcode secrets, tokens, API keys or passwords
+- **ALWAYS** use vault services (Key Vault, Secrets Manager) for secrets
+- **ALWAYS** validate and sanitize inputs at system boundaries
+- **ALWAYS** apply the principle of least privilege
+- If a secret is detected in code or logs → **STOP and alert the PM**
+
+### 2. Scope & Ownership
+
+Each agent has primary areas of responsibility:
+
+| Agent | Primary ownership |
+|---|---|
+| Architect | `docs/decisions.md`, API contracts, diagrams |
+| Backend | `src/api/`, `src/application/`, `src/domain/`, `src/infrastructure/` |
+| Frontend | `src/components/`, `src/features/`, `src/hooks/`, `src/ui/` |
+| DevOps | `infra/`, `pipelines/`, `docker/`, `.github/workflows/`, `*.tf` |
+| Security | Threat models, security reviews, security configs |
+| QA | `tests/`, `*.test.*`, `*.spec.*`, test plans |
+
+Crossing boundaries is permitted when the task explicitly requires it, there
+is a documented justification, or the PM has approved the scope change.
+
+### 3. Process — Spec-Driven Development
+
+Before writing code, verify that `docs/spec.md` has requirements for the
+task and that the spec is **APPROVED**. Valid exceptions that do not require
+a full spec:
+
+- **Bugfixes** — corrections of errors in existing code
+- **Emergencies** — production hotfixes (document post-mortem)
+- **Dependencies/CVE** — vulnerability updates
+- **Config/metadata** — minor configuration changes
+
+### 4. Destructive Operations
+
+The following **require explicit PM confirmation** before execution:
+
+- Delete files, directories, tables, databases or cloud resources
+- `DROP`, `DELETE`, `TRUNCATE` on databases
+- `terraform destroy` or `kubectl delete`
+- Purge caches, message queues or storage
+- Revoke access, tokens or certificates
+- Force-push or rebase on shared branches
+
+Before destroying, the agent must present: **what**, **why**, **impact**
+and **reversibility** — then wait for approval.
+
+### 5. Data & PII
+
+- **NEVER** include, repeat or process real customer data
+- **NEVER** log sensitive data (tokens, passwords, PII)
+- **ALWAYS** use synthetic data for tests and examples
+- If real data is detected → **STOP immediately**
+
+### 6. Quality
+
+- Self-review before presenting code
+- New code must have appropriate tests (unit, integration, dry-run)
+- No dead code, unused imports or TODOs in commits
+- Explicit error handling with context — no silent failures
+
+### 7. Environments
+
+Promotion order (never skip):
+```
+dev → test → acceptance → engineering → production
+```
+
+- **NEVER** make changes directly in production without change control
+- **ALWAYS** use IaC and pipelines — never manual console changes
+- Production data must never be copied to lower environments without
+  anonymization
+
+### 8. Documentation
+
+- Document technical decisions in `docs/decisions.md` using ADR format
+- Update `docs/session-log.md` at the end of each session
+- If scope changes, update `docs/spec.md` before implementing
+
+## Deployment modes
+
+The wizard offers two guardrail deployment strategies:
+
+| Mode | How it works | Best for |
+|---|---|---|
+| **split** (recommended) | Critical guardrails always active in global instructions (`copilot-instructions.md`, `CLAUDE.md`, `guardrails.mdc`) + full detailed file (`guardrails.instructions.md`) | Regulated teams, larger repos, multi-agent workflows |
+| **embedded** | Only critical guardrails in global instructions; no separate file | Small/fast projects, lightweight setups |
+
+Select the mode during the wizard or set it in `understudy.yaml`:
+
+```yaml
+guardrails:
+  mode: "split"   # or "embedded"
+```
+
+### What "critical" vs "full" means
+
+- **Critical guardrails** (always active, both modes): the compact block
+  between `<!-- GUARDRAILS_START -->` and `<!-- GUARDRAILS_END -->` markers.
+  Covers security, destructive ops, data/PII, environments, scope and
+  process — enough for most sessions.
+- **Full guardrails** (split mode only): the complete file
+  `guardrails.instructions.md` with detailed rules, ownership tables,
+  examples and checklists for all 8 categories. Applied via `applyTo: "**"`
+  in VS Code, activated via `/instructions` in Copilot CLI.
+
+## Enforcement per platform
+
+| Platform | Guardrails layer | How it's enforced |
+|---|---|---|
+| **Copilot CLI** | `copilot-instructions.md` (critical block) + `guardrails.instructions.md` (full, via `/instructions`) | Instruction files — the model follows them |
+| **VS Code** | Same files, but `guardrails.instructions.md` auto-applies via `applyTo: "**"` | Auto-applied to every file |
+| **Claude Code** | `CLAUDE.md` (critical block) + `.claude/hooks/guardrails-check.sh` (PreToolUse) + `settings.json` (deny list) | **Three layers**: instructions + hook that blocks destructive commands + file access deny |
+| **Cursor** | `.cursor/rules/guardrails.mdc` (critical block, `alwaysApply: true`) | Always-applied rule |
+
+### Claude Code's extra safety
+
+Claude Code is the only platform with active enforcement beyond instructions:
+
+1. **PreToolUse hook** (`guardrails-check.sh`) — runs before every shell
+   command. Blocks patterns like `rm -rf`, `terraform destroy`,
+   `kubectl delete`, `DROP TABLE`, `git push --force`, etc. Exits with
+   code 2 to block, 0 to allow.
+
+2. **Permission deny list** (`settings.json`) — Claude refuses to read or
+   write files matching the deny list (`.env`, `secrets/`, `*.key`,
+   `*.pem`, etc.).
+
+3. **Secret detection** — the hook warns (but does not block) when commands
+   reference `.env`, `.key`, `.pem`, `credentials` or `password` patterns.
+
+### Customizing the hook
+
+The destructive patterns are defined in the `DESTRUCTIVE_PATTERNS` array at
+the top of `.claude/hooks/guardrails-check.sh`. To add a new pattern:
+
+```bash
+DESTRUCTIVE_PATTERNS=(
+    # ... existing patterns ...
+    "my-custom-dangerous-command"
+)
+```
+
+To relax a pattern (allow a specific destructive operation), remove it from
+the array — but document why in `docs/decisions.md`.
+
+## Customizing guardrails
+
+### Adding rules
+
+Edit `guardrails.instructions.md` (Copilot) or `guardrails.mdc` (Cursor)
+directly. The critical block inside `copilot-instructions.md` / `CLAUDE.md`
+is regenerated by the wizard — add custom rules outside the
+`GUARDRAILS_START` / `GUARDRAILS_END` markers.
+
+### Disabling rules
+
+Do **not** remove guardrails without documentation. If a rule is too strict
+for your project, document the exception in `docs/decisions.md` as an ADR
+and modify the rule accordingly.
+
+---
+
+Next: [Roles & Spec-Driven Development](05-roles-and-workflow.md)

--- a/docs/05-roles-and-workflow.md
+++ b/docs/05-roles-and-workflow.md
@@ -1,0 +1,265 @@
+# 5. Roles & Spec-Driven Development
+
+This chapter explains how Understudy's role system works and the
+spec-driven workflow that ties everything together.
+
+## How roles work
+
+Every Understudy deployment ships 6 **core roles** plus any **optional
+roles** you select. Each role is a Markdown file with:
+
+- **Identity** — who the agent is, their code name and motto
+- **Expertise** — specific technologies and domains
+- **How they work** — step-by-step process including context files
+- **Standards** — code quality, naming, error handling rules
+- **Team interaction** — which agents they receive from and deliver to
+
+### Core roles (always deployed)
+
+| Role | Code name | Focus |
+|---|---|---|
+| 🏛️ Architect | Architect | System design, APIs, databases, trade-offs, ADRs |
+| ⚙️ Backend | Backend | Services, business logic, data contracts |
+| 🎨 Frontend | Frontend | UI, accessibility, UX, state management |
+| 🚀 DevOps | DevOps | CI/CD, containers, IaC, cloud, deploys |
+| 🔒 Security | Security | Threat modeling, input validation, secrets, OWASP |
+| 🧪 QA | QA | Test plans, unit/integration/E2E, quality gates |
+
+### Optional roles (from `roles/`)
+
+| Role | When to use |
+|---|---|
+| 📊 data-engineer | ETL/ELT, warehouses, streaming, data governance |
+| 🌿 git-specialist | Git workflows, branch policies, PR hygiene |
+| 📱 mobile-engineer | iOS, Android, React Native, Flutter |
+| 🤖 ml-engineer | ML models, MLOps, LLMs, RAG, responsible AI |
+| 📖 repo-documenter | Codebase understanding, architecture docs, onboarding |
+| 🐚 shell-scripting | Bash/sh automation, cross-platform scripting |
+| 📝 tech-writer | Technical docs, API reference, tutorials |
+| 🧭 sre | SLOs, observability, incidents, chaos engineering |
+| 🐉 caveman | Token-efficient prose (opt-in, see [chapter 10](10-caveman-mode.md)) |
+
+### Auto-deployed roles
+
+The wizard includes some optional roles automatically:
+
+| Role | Condition |
+|---|---|
+| `git-specialist` | Always included |
+| `repo-documenter` | Always included |
+| `shell-scripting` | Included when `*.sh`, `*.bash` or `*.zsh` files are detected |
+
+### Adding and creating roles
+
+```bash
+# Pick from the existing catalog
+understudy --add-member
+
+# Create a brand new role from scratch
+understudy --create-role
+```
+
+`--create-role` walks you through an interactive wizard that asks for the
+role name, title, description, areas of expertise and a motto. The
+resulting file is saved in `roles/` and is available for every future
+deployment — not just the current project.
+
+### Role file format
+
+Every role file (`.instructions.md`) follows the same structure:
+
+```markdown
+# Role Title — Role Title Instructions
+
+## Identity
+You are the Role Title of the Understudy team. Your code name is **RoleName**.
+Description of what you do.
+Your motto: "..."
+
+## Expertise
+- Technology 1
+- Technology 2
+
+## How you work
+1. Read docs/spec.md
+2. Consult docs/decisions.md
+3. ...
+
+## Standards
+- Clean code
+- Error handling
+- ...
+
+## Team interaction
+- ← Architect: You receive design decisions
+- → Security: You consult on security
+- ← PM: You resolve requirements questions
+```
+
+You can create role files manually — just follow this format and place them
+in `roles/`.
+
+## How roles are deployed per platform
+
+The same role file is adapted to each platform's format:
+
+| Platform | Where the role lives | How it's activated |
+|---|---|---|
+| Copilot CLI | `.github/instructions/<role>.instructions.md` | `/instructions` toggle |
+| VS Code | `.github/instructions/<role>.instructions.md` | Auto-applied by `applyTo` glob |
+| Claude Code | `.claude/agents/<role>.md` (with YAML frontmatter: name, model, tools) | Invoke the agent by name |
+| Cursor | `.cursor/agents/<role>.md` (with YAML frontmatter: name, model) | Agent panel |
+
+The wizard handles the conversion automatically. For Claude and Cursor, it
+wraps the role content in a frontmatter block with the recommended model
+from `understudy.yaml`.
+
+## The `applyTo` system (VS Code)
+
+In VS Code, each role's `.instructions.md` has a YAML frontmatter:
+
+```yaml
+---
+applyTo: "src/api/**,src/application/**"
+---
+```
+
+When you open or edit a file that matches the glob, VS Code auto-applies
+that role's instructions. This means you don't have to switch roles
+manually — the right persona activates based on what you're editing.
+
+Default `applyTo` patterns (configurable in `understudy.yaml → roles.*`):
+
+| Role | Default `applyTo` |
+|---|---|
+| Architect | `docs/**` |
+| Backend | `src/api/**,src/application/**,src/domain/**,src/infrastructure/**` |
+| Frontend | `src/components/**,src/features/**,src/hooks/**,src/ui/**,**/*.tsx,**/*.jsx` |
+| DevOps | `infra/**,pipelines/**,docker/**,.github/workflows/**,**/*.tf` |
+| Security | _(empty — manual activation only)_ |
+| QA | `tests/**,**/*.test.*,**/*.spec.*,**/*Tests*/**` |
+| Guardrails | `**` _(always active on every file)_ |
+
+## Spec-Driven Development
+
+Spec-Driven Development is Understudy's workflow model. The idea is
+simple: **agree on what to build before building it**.
+
+### The spec lifecycle
+
+```
+1. PM writes initial requirements
+        │
+        ▼
+2. Architect designs solution
+   (proposes alternatives, writes ADR)
+        │
+        ▼
+3. Security reviews the design
+   (threat model, authZ, PII)
+        │
+        ▼
+4. PM approves the spec
+        │
+   ┌────┴────┐
+   ▼         ▼
+5. Backend   Frontend
+   implements API    implements UI
+   │         │
+   └────┬────┘
+        ▼
+6. QA writes and runs tests
+        │
+        ▼
+7. DevOps deploys
+        │
+        ▼
+8. Security does final review
+        │
+        ▼
+9. Session log updated
+```
+
+### The three context files
+
+These files are Understudy's **persistent memory** — they survive between
+sessions and keep every agent aligned:
+
+| File | Purpose | Updated by |
+|---|---|---|
+| `docs/spec.md` | Requirements and scope (living contract) | PM + Architect |
+| `docs/decisions.md` | ADR log — what was decided and why | All agents (mainly Architect) |
+| `docs/session-log.md` | What was done, what's pending | Whoever ends the session |
+
+A fourth file, `docs/team-roster.md`, tracks which agents are active in the
+project and where their files live.
+
+### Session protocol
+
+**Start of session:**
+
+```
+Read docs/session-log.md, docs/spec.md and docs/decisions.md
+and tell me where we are.
+```
+
+On VS Code this is the `start-session.prompt.md` prompt. On Claude Code,
+`/project:start-session`. On Copilot CLI and Cursor, paste the message.
+
+**End of session:**
+
+```
+Update docs/session-log.md with what we did today,
+any new decisions and pending items.
+```
+
+On VS Code: `end-session.prompt.md`. On Claude Code:
+`/project:end-session`.
+
+### ADR format (Architecture Decision Records)
+
+When a decision is made, the agent records it in `docs/decisions.md`:
+
+```markdown
+## ADR-0005: Use PostgreSQL for customer data
+
+**Date:** 2026-05-12
+**Status:** Approved
+**Context:** We need a relational store for customer records with ACID guarantees.
+**Decision:** PostgreSQL 16 with pgvector for future embedding search.
+**Alternatives considered:**
+- MongoDB — rejected (schema flexibility not needed, ACID harder)
+- MySQL — rejected (pgvector not available)
+**Consequences:** Backend needs pg driver; DevOps adds PG to Terraform.
+```
+
+### When is spec not required?
+
+The guardrails define four exceptions where code can be written without a
+full approved spec:
+
+1. **Bugfixes** — corrections of errors in existing code
+2. **Emergencies** — production hotfixes (document post-mortem)
+3. **Dependencies/CVE** — vulnerability updates
+4. **Config/metadata** — minor configuration changes
+
+In all cases, document what you did in `docs/session-log.md`.
+
+## Sub-agents (parallel work)
+
+On platforms that support it (Copilot CLI, VS Code, Claude Code), you can
+launch parallel sub-agents:
+
+```
+Implement the login feature end to end. Use one sub-agent for Backend
+(API + tests) and another for Frontend (form + tests). Both must follow
+docs/decisions.md ADR-0005.
+```
+
+The AI splits the work into independent tasks that run in parallel and
+converge their results. This reduces wall time when pieces are independent
+(e.g. Backend API and Frontend form can be built simultaneously).
+
+---
+
+Next: [Cross-Platform Workflows](08-cross-platform-workflows.md)

--- a/docs/08-cross-platform-workflows.md
+++ b/docs/08-cross-platform-workflows.md
@@ -14,7 +14,7 @@ platforms:
 
 models:
   architect: "claude-opus-4.6"
-  backend:   "claude-sonnet-4.6"
+  backend:   "claude-sonnet-4.5"
   security:  "claude-opus-4.6"
 
 guardrails:
@@ -22,6 +22,20 @@ guardrails:
 ```
 
 Run the wizard once and both Copilot and Claude files are generated.
+
+## Deploying to multiple platforms at once
+
+The fastest way to set up a multi-platform project is `--here`:
+
+```bash
+cd /path/to/your/repo
+understudy --here          # infers everything, deploys to all 3 platforms by default
+understudy --here --yes    # fully unattended
+```
+
+By default all three platforms are enabled. If you only want a subset, run
+without `--here` (interactive wizard) or set `platforms.*` in
+`understudy.yaml` before deploying.
 
 ## Typical daily flow
 
@@ -52,6 +66,28 @@ any new decisions and pending items.
 On VS Code and Claude Code this is a one-click prompt/command; on Copilot
 CLI and Cursor it's a plain message. Either way the file is the source of
 truth.
+
+## Caveman mode across platforms
+
+Caveman mode is a cross-platform feature. If you deploy with `--caveman`,
+the role file is placed in the correct location for each enabled platform:
+
+| Platform | Role location | Slash commands | Hooks |
+|---|---|---|---|
+| Copilot CLI / VS Code | `.github/instructions/caveman.instructions.md` | `.github/prompts/compress.prompt.md` | Marker block in `copilot-instructions.md` |
+| Claude Code | `.claude/agents/caveman.md` | `.claude/commands/compress.md` | Real `SessionStart` / `UserPromptSubmit` hooks |
+| Cursor | `.cursor/agents/caveman.md` | `.cursor/commands/compress.md` | `.cursor/rules/00-caveman-active.mdc` |
+
+The `understudy-compress` script itself is platform-independent — it
+operates on Markdown files directly, regardless of which AI tool you are
+using. See [Caveman Mode](10-caveman-mode.md) for details.
+
+## Shared configuration
+
+All platforms read the same `understudy.yaml` for models, guardrails and
+session behavior. When you change the config, re-run the wizard and the new
+settings apply to all platforms. Note that existing files are preserved (see
+[Configuration → Reapplying changes](09-configuration.md#reapplying-changes)).
 
 ---
 

--- a/docs/09-configuration.md
+++ b/docs/09-configuration.md
@@ -33,10 +33,33 @@ models:
   frontend:  "claude-sonnet-4.5"
   devops:    "claude-haiku-4.5"
   security:  "claude-sonnet-4.5"
-  qa:        "claude-sonnet-4.5"
+  qa-engineer: "claude-sonnet-4.5"
+
+roles:
+  architect:
+    enabled: true
+    apply_to: "docs/**"
+  backend:
+    enabled: true
+    apply_to: "src/api/**,src/application/**,src/domain/**,src/infrastructure/**"
+  frontend:
+    enabled: true
+    apply_to: "src/components/**,src/features/**,src/hooks/**,src/ui/**,**/*.tsx,**/*.jsx"
+  devops:
+    enabled: true
+    apply_to: "infra/**,pipelines/**,docker/**,.github/workflows/**,**/*.tf"
+  security:
+    enabled: true
+    apply_to: ""
+  qa-engineer:
+    enabled: true
+    apply_to: "tests/**,**/*.test.*,**/*.spec.*,**/*Tests*/**"
 
 guardrails:
   mode: "split"            # "split" keeps full file; "embedded" inlines critical rules
+
+spec:
+  require_before_coding: true  # block coding until spec.md is approved
 
 session:
   auto_read_context: true  # hint for start-session prompts
@@ -53,8 +76,11 @@ git:
 | --- | --- |
 | `project.*` | Metadata used by templates (name, PM) |
 | `platforms.*` | Toggle Copilot / Claude / Cursor deployment |
-| `models.<role>` | Recommended model per role (shown to the user; applied directly in Claude and Cursor agents) |
+| `models.<role>` | Recommended model per role (shown to the user; applied directly in Claude and Cursor agents). Role key is `qa-engineer` (not `qa`) |
+| `roles.<role>.enabled` | `true` = the wizard deploys this role; `false` = skip it |
+| `roles.<role>.apply_to` | Glob pattern for VS Code auto-applied instructions. When you edit a file matching this pattern, the role's instructions activate automatically. Empty = manual activation only |
 | `guardrails.mode` | `split` = dedicated guardrails file; `embedded` = critical rules only |
+| `spec.require_before_coding` | `true` = agents are instructed to block coding until `docs/spec.md` is approved (exceptions: bugfixes, emergencies, CVEs, config) |
 | `session.*` | Hints used in `start-session` / `end-session` prompts |
 | `git.local_config` | `true` = gitignore AI agents, instructions, hooks — kept local only |
 | `git.local_memory` | `true` = gitignore spec.md, decisions.md, session-log.md — kept local only |
@@ -73,9 +99,126 @@ You can also choose them interactively during `understudy` — the wizard asks b
 
 ## Reapplying changes
 
-After editing `understudy.yaml`, re-run the wizard to regenerate the
-affected files. Existing customizations in your repo are preserved unless
-the file is one of the Understudy-owned templates.
+After editing `understudy.yaml`, re-run the wizard to regenerate the affected files.
+
+### How the wizard handles existing files
+
+The wizard uses a **skip-if-exists** strategy: if a target file already
+exists in your project, it is **never overwritten**. Only missing files are
+created. This means:
+
+- Changing `models.*` or `roles.*.apply_to` in `understudy.yaml` **does not
+  retroactively update** agent files that were already deployed. The new
+  values only take effect for files created in future runs.
+- The **one exception** is the guardrails block: `inject_guardrails_block`
+  replaces the content between `<!-- GUARDRAILS_START -->` and
+  `<!-- GUARDRAILS_END -->` markers inside `copilot-instructions.md`,
+  `CLAUDE.md` and `guardrails.mdc`, regardless of whether the file already
+  existed.
+
+### Step-by-step process
+
+1. **Edit `understudy.yaml`** in your project root with your new configuration.
+2. **Re-run the wizard** from your project directory:
+   ```bash
+   understudy --here
+   # or if installed via clone:
+   ./wizard.sh --here
+   ```
+3. **Confirm** when prompted to apply the changes.
+4. **Review** the output — the wizard logs every file it creates and every
+   file it skips (with "already exists, preserving" messages).
+
+### What changes and what doesn't
+
+| Change in YAML | Effect on re-run | To force the update |
+| --- | --- | --- |
+| `platforms.*` (enable a new platform) | New platform files are created; existing platform files are untouched | — (works automatically) |
+| `platforms.*` (disable a platform) | Nothing is deleted; files remain in place | Delete the platform directory manually (`.github/`, `.claude/`, `.cursor/`) |
+| `models.<role>` | No effect — existing agent files are preserved with the old model value | Delete the specific agent file and re-run the wizard, or edit the file manually |
+| `roles.<role>.apply_to` | No effect — existing `.instructions.md` files keep their old `applyTo` frontmatter | Edit the `applyTo` in the `.instructions.md` file directly |
+| `guardrails.mode` | The guardrails block between `GUARDRAILS_START` / `GUARDRAILS_END` markers is refreshed | — (works automatically) |
+| `git.local_config` / `git.local_memory` | `.gitignore` block is appended if not already present | — (works automatically; idempotent) |
+| `project.name` / `project.pm` | No effect — existing template files keep the old values | Delete `docs/spec.md`, `docs/team-roster.md` etc. and re-run |
+
+### Example: Adding Copilot to an existing Claude-only project
+
+Original config:
+```yaml
+platforms:
+  copilot: false
+  claude: true
+  cursor: false
+```
+
+Updated config:
+```yaml
+platforms:
+  copilot: true      # newly enabled
+  claude: true
+  cursor: false
+```
+
+After running `understudy --here`:
+- New Copilot files are created (`AGENTS.md`, `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md`, `.github/prompts/*.prompt.md`)
+- Claude files remain exactly as they were
+- New optional role files for Copilot (`git-specialist`, `repo-documenter`, `shell-scripting` if applicable)
+- `docs/team-roster.md` is updated to include the new roles (only if the role wasn't already listed)
+
+### Example: Changing recommended models
+
+If you change the model for a role:
+```yaml
+models:
+  backend: "claude-opus-4.6"      # was claude-sonnet-4.5
+```
+
+The wizard **will not** update the existing `backend.instructions.md` or `.claude/agents/backend.md` because those files already exist. To apply the new model:
+
+1. **Option A** — Edit the file directly:
+   - Copilot: edit the `{{MODEL_BACKEND}}` placeholder value in `.github/instructions/backend.instructions.md`
+   - Claude: edit the `model:` field in `.claude/agents/backend.md` frontmatter
+   - Cursor: edit the `model:` field in `.cursor/agents/backend.md` frontmatter
+
+2. **Option B** — Delete and regenerate:
+   ```bash
+   # Delete the specific file(s)
+   rm .github/instructions/backend.instructions.md
+   rm .claude/agents/backend.md
+   rm .cursor/agents/backend.md
+   # Re-run the wizard
+   understudy --here
+   ```
+
+### What is NEVER touched
+
+- Your source code, `package.json`, CI workflows, database migrations
+- Any file not in the Understudy-owned list (see [Introduction → Files Understudy produces](01-introduction.md))
+- Existing Understudy files that were already deployed
+
+### Troubleshooting regeneration
+
+**Files don't reflect the new YAML values:**
+- This is expected — the wizard skips existing files. Delete the file you want to regenerate and re-run.
+
+**The guardrails block didn't update:**
+- Ensure the `<!-- GUARDRAILS_START -->` and `<!-- GUARDRAILS_END -->` markers are still present in the file. If you deleted them, the wizard cannot find the block to replace.
+
+**Need a full reset of all Understudy files:**
+```bash
+# Remove all Understudy-generated files
+rm -f AGENTS.md CLAUDE.md understudy.yaml
+rm -rf .github/instructions .github/prompts .github/copilot-instructions.md
+rm -rf .claude
+rm -rf .cursor/agents .cursor/commands .cursor/rules
+rm -f docs/spec.md docs/decisions.md docs/session-log.md docs/team-roster.md
+# Re-run the wizard for a clean deploy
+understudy --here
+```
+
+**If you lose a customization:**
+- Check your git history: `git log -p path/to/file`
+- Restore from git: `git checkout path/to/file`
 
 ## Optional roles auto-deploy
 
@@ -94,6 +237,53 @@ Claude, Cursor) and the `docs/team-roster.md` is updated automatically.
 There is currently no YAML key to disable auto-deploy; the behavior is
 hardcoded in the wizard.
 
+## Module system
+
+Understudy supports **opt-in modules** under `modules/<name>/`. Each module
+is a self-contained directory with a `module.yaml` manifest that the wizard
+discovers automatically — no edits to `wizard.sh` required.
+
+### Module manifest (`module.yaml`)
+
+```yaml
+name: caveman
+title: "Caveman mode"
+description: "Token-efficient communication overlay."
+flag: --caveman              # CLI flag exposed by the wizard
+default: false               # true = always included; false = opt-in
+role_file: role.instructions.md
+bin: bin/understudy-compress  # optional executable (chmod +x on install)
+status: stable               # stable | experimental | deprecated
+```
+
+The wizard registers the flag from the manifest, so `understudy --help`
+lists all available modules dynamically.
+
+### Post-install actions (`post-install.flags`)
+
+A module can ship optional post-install automation in a tab-separated
+`post-install.flags` file:
+
+```
+--caveman-hooks	bin/install-hooks install --mode remind --target {TARGET}	Install reinforcement hooks.
+--caveman-commands	bin/install-commands install --target {TARGET}	Install slash commands.
+```
+
+When the user passes the flag (e.g. `understudy --caveman --caveman-hooks`),
+the wizard runs the command from the module directory after the regular
+deploy finishes. The `{TARGET}` token is replaced with the absolute path of
+the deployment target.
+
+### Creating your own module
+
+1. Create a directory under `modules/your-module/`
+2. Add a `module.yaml` manifest (see format above)
+3. Add a `role.instructions.md` following the standard role format
+4. Optionally add `post-install.flags` for extra automation
+5. The wizard will discover it automatically on the next run
+
+To remove a module, delete its directory. No other files need to be edited.
+
 ---
 
-Next: [Troubleshooting and FAQ](10-troubleshooting.md)
+Next: [Caveman Mode](10-caveman-mode.md)

--- a/docs/10-caveman-mode.md
+++ b/docs/10-caveman-mode.md
@@ -1,4 +1,4 @@
-# 11. Caveman Mode
+# 10. Caveman Mode
 
 > *"Why use many token when few token do trick."* — `modules/caveman/role.instructions.md`
 
@@ -364,3 +364,7 @@ actually uses, not on toy fixtures. Word count is a rough proxy.
 - [Configuration reference](09-configuration.md) — adding optional roles
 - [Cross-Platform Workflows](08-cross-platform-workflows.md) — using
   `caveman` alongside other team members
+
+---
+
+Next: [Troubleshooting and FAQ](11-troubleshooting.md)

--- a/docs/11-troubleshooting.md
+++ b/docs/11-troubleshooting.md
@@ -1,4 +1,4 @@
-# 10. Troubleshooting and FAQ
+# 11. Troubleshooting and FAQ
 
 ## I don't want AI config files in my git repo
 
@@ -135,6 +135,98 @@ Security).
 Use the repo's
 [issue templates](https://github.com/erniker/understudy/issues/new/choose).
 Security issues: see [SECURITY.md](../SECURITY.md).
+
+## Can I use `--here` with modules like `--caveman`?
+
+Yes, flags combine freely:
+
+```bash
+understudy --here --caveman                          # infer + caveman role
+understudy --here --yes --caveman --caveman-hooks    # fully unattended with hooks
+```
+
+The order does not matter. Module flags (`--caveman`, `--caveman-hooks`,
+`--caveman-commands`, `--caveman-statusline`) are independent of `--here` /
+`--yes`.
+
+## Windows: the wizard fails or shows garbled output
+
+Understudy requires a **bash-compatible shell**. On Windows, use one of:
+
+- **Git Bash** (installed with Git for Windows) — recommended
+- **WSL** (Windows Subsystem for Linux)
+- **MSYS2** or **Cygwin**
+
+PowerShell and `cmd.exe` are **not supported** for running the wizard
+directly. However, once deployed, the AI tools (Copilot, Claude, Cursor)
+work normally regardless of your shell.
+
+## `understudy-compress` says "python3 not found"
+
+The compress script requires Python ≥ 3.8. Install it:
+
+- **Windows**: `winget install Python.Python.3.13` or `scoop install python`
+- **macOS**: `brew install python3` (or use the system Python)
+- **Linux**: `sudo apt install python3` / `sudo dnf install python3`
+
+The compress script is the only part of Understudy that requires Python —
+the wizard and all configuration are pure bash.
+
+## I created a role with `--create-role` but it's not in my project
+
+`--create-role` saves the role to the `roles/` catalog inside the
+Understudy installation (`~/.understudy/roles/`). To add it to an
+existing project:
+
+```bash
+understudy --add-member
+# → Select the role from the menu
+```
+
+Alternatively, re-run the wizard and the role will be available for
+selection.
+
+## How do I remove a platform I no longer use?
+
+The wizard does not delete platform files when you set `platforms.X: false`.
+To remove a platform's files, delete them manually:
+
+```bash
+# Remove Copilot files
+rm -f AGENTS.md .github/copilot-instructions.md
+rm -rf .github/instructions .github/prompts
+
+# Remove Claude Code files
+rm -f CLAUDE.md
+rm -rf .claude
+
+# Remove Cursor files
+rm -rf .cursor/agents .cursor/commands
+rm -f .cursor/rules/understudy-global.mdc .cursor/rules/guardrails.mdc
+```
+
+## The team-roster.md has duplicate entries
+
+This can happen if you re-run the wizard or `--add-member` multiple times.
+The wizard checks for duplicates by role name, but edge cases exist. Edit
+`docs/team-roster.md` manually to remove the duplicates — the file is plain
+Markdown.
+
+## Can multiple developers use Understudy on the same repo?
+
+Yes. Two common setups:
+
+1. **Shared config (default)** — all Understudy files are committed.
+   Everyone uses the same agents, guardrails and context files. Session
+   logs are shared, so the team sees what each person did.
+
+2. **Local-only config** (`git.local_config: true`) — each developer has
+   their own AI configuration. Useful when not everyone uses the same AI
+   tool or when AI config is considered private.
+
+   In this mode, `docs/spec.md`, `docs/decisions.md` and
+   `docs/session-log.md` can still be committed (`git.local_memory: false`)
+   so the team shares context even if agents are private.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,21 +9,24 @@ restructuring.
 1. [Introduction and Core Concepts](01-introduction.md)
 2. [Quick Start](02-quick-start.md)
 3. [Platform Capability Matrix](03-platform-comparison.md)
-4. Platforms
+4. [Guardrails](04-guardrails.md)
+5. [Roles & Spec-Driven Development](05-roles-and-workflow.md)
+6. Platforms
    - [GitHub Copilot CLI](platforms/copilot-cli.md)
    - [VS Code Copilot](platforms/vscode-copilot.md)
    - [Claude Code](platforms/claude-code.md)
    - [Cursor](platforms/cursor.md)
-5. [Cross-Platform Workflows](08-cross-platform-workflows.md)
-6. [Configuration Reference (`understudy.yaml`)](09-configuration.md)
+7. [Cross-Platform Workflows](08-cross-platform-workflows.md)
+8. [Configuration Reference (`understudy.yaml`)](09-configuration.md)
    - [Local-only mode](09-configuration.md#local-only-mode) — keep AI config out of git
-7. [Troubleshooting and FAQ](10-troubleshooting.md)
-8. [Caveman Mode (token-efficient role + compress script)](11-caveman-mode.md)
-   - [Evals harness](../tests/evals/README.md) — reproducible token-reduction numbers
+   - [Module system](09-configuration.md#module-system) — opt-in modules like caveman
+9. [Caveman Mode (token-efficient role + compress script)](10-caveman-mode.md)
+   - [Evals harness](../modules/caveman/evals/README.md) — reproducible token-reduction numbers
+10. [Troubleshooting and FAQ](11-troubleshooting.md)
 
-> File names keep their historical numeric prefix (`08-`, `09-`, `10-`,
-> `11-`) for stable external links; the index above is the recommended
-> reading order.
+> File names use numeric prefixes for stable ordering. The gap at 06-07 is
+> reserved for future chapters; the index above is the recommended reading
+> order.
 
 ## How to read this
 

--- a/docs/platforms/cursor.md
+++ b/docs/platforms/cursor.md
@@ -132,6 +132,20 @@ The wizard deploys commands under `.cursor/commands/`:
 
 Invoke them from Cursor's command palette or chat.
 
+### Caveman commands (opt-in)
+
+If you deploy with `--caveman --caveman-commands`, two additional commands
+are installed:
+
+| Command | Purpose |
+|---|---|
+| `compress.md` | Compress a Markdown file using the caveman compressor |
+| `restore.md` | Restore a compressed file from its `.original.md` backup |
+
+They live in `.cursor/commands/` and wrap
+`modules/caveman/bin/understudy-compress` with the same safety contract
+(refuses symlinks, files outside CWD, sensitive filenames and content).
+
 ## Tips specific to Cursor
 
 - You can combine agents: switch between architect → backend → security

--- a/modules/caveman/README.md
+++ b/modules/caveman/README.md
@@ -22,7 +22,7 @@ an Understudy deployment. Inspired by
 | [`tests/`](tests/) | Bats coverage for the role, the compressor, the installers and the wizard's `--caveman` / `--caveman-hooks` / `--caveman-commands` / `--caveman-statusline` flags. |
 
 The user-facing chapter for caveman lives in
-[`docs/11-caveman-mode.md`](../../docs/11-caveman-mode.md) (kept at its
+[`docs/10-caveman-mode.md`](../../docs/10-caveman-mode.md) (kept at its
 historical path so existing external links keep working).
 
 ## How to enable it
@@ -144,7 +144,7 @@ rm -rf modules/caveman
 
 Then update:
 
-- `docs/11-caveman-mode.md` (delete or mark as removed)
+- `docs/10-caveman-mode.md` (delete or mark as removed)
 - `README.md` and `CHANGELOG.md` (note the removal)
 
 That's it. There are no orphan references inside `wizard.sh`,

--- a/modules/caveman/bin/understudy-compress
+++ b/modules/caveman/bin/understudy-compress
@@ -40,7 +40,7 @@ Token measurement:
   - Optional: prompts to install tiktoken on first run; --no-install skips
     the prompt, --yes accepts non-interactively.
 
-Part of the Understudy project (caveman mode). See docs/11-caveman-mode.md.
+Part of the Understudy project (caveman mode). See docs/10-caveman-mode.md.
 """
 
 from __future__ import annotations

--- a/modules/caveman/evals/README.md
+++ b/modules/caveman/evals/README.md
@@ -1,6 +1,6 @@
 # Caveman evals harness
 
-A small, opt-in harness to defend the savings claim of [caveman mode](../../docs/11-caveman-mode.md)
+A small, opt-in harness to defend the savings claim of [caveman mode](../../docs/10-caveman-mode.md)
 with reproducible numbers. Two halves:
 
 1. **Dogfood** — runs `modules/caveman/bin/understudy-compress` against every Markdown file


### PR DESCRIPTION
## Description

Complete documentation audit against the source code (wizard.sh, install.sh, understudy.yaml, all templates and modules). Fixes inaccuracies, adds two new chapters, and expands several existing sections. No code changes.

---

## Type of change

- [x] 📝 `docs` — documentation only

---

## What changes?

- New chapter `04-guardrails.md`: 8 categories, deployment modes, per-platform enforcement, Claude hook internals, customization
- New chapter `05-roles-and-workflow.md`: role system, applyTo globs, spec lifecycle, session protocol, ADR format, sub-agents
- `09-configuration.md`: added missing `roles.*` and `spec.*` YAML fields; rewrote Reapplying-changes to reflect skip-if-exists; added Module system section
- `11-troubleshooting.md`: 7 new FAQs (Windows, python3, --create-role, removing platforms, duplicates, multi-dev, --here + modules)
- `02-quick-start.md`: fixed chapter ref, added Uninstall section
- `08-cross-platform-workflows.md`: added --here section, caveman cross-platform table, shared config note
- Renamed 10-troubleshooting to 11, 11-caveman-mode to 10; updated all cross-references
- Fixed broken evals link in docs/README.md, added modules/ to README tree, added .cursor/commands/ to intro tree

---

## How to test

```bash
# Verify navigation chain
grep 'Next:' docs/*.md

# Verify no stale references outside CHANGELOG/RESULTS
grep -rn '11-caveman\|10-troubleshooting' docs/ README.md CONTRIBUTING.md
```

---

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] `CHANGELOG.md` updated in the `[Unreleased]` section
- [x] `bash -n wizard.sh` passes without errors
- [x] ShellCheck passes locally (or new warnings are justified)
- [x] Affected documentation is updated