### PR TITLE
docs: add hands-on tutorials for all 4 platforms

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,14 @@ restructuring.
    - [Evals harness](../modules/caveman/evals/README.md) — reproducible token-reduction numbers
 10. [Troubleshooting and FAQ](11-troubleshooting.md)
 
+### 📖 Tutorials (hands-on walkthroughs)
+
+- [Tutorials index](tutorials/README.md)
+  - [GitHub Copilot CLI tutorial](tutorials/copilot-cli-tutorial.md)
+  - [VS Code Copilot tutorial](tutorials/vscode-copilot-tutorial.md)
+  - [Claude Code tutorial](tutorials/claude-code-tutorial.md)
+  - [Cursor tutorial](tutorials/cursor-tutorial.md)
+
 > File names use numeric prefixes for stable ordering. The gap at 06-07 is
 > reserved for future chapters; the index above is the recommended reading
 > order.
@@ -32,6 +40,7 @@ restructuring.
 
 - First time here? Read [Introduction](01-introduction.md) → [Quick Start](02-quick-start.md).
 - Looking for a feature on your tool? Jump to the platform page.
+- Want a guided walkthrough? Start with the [tutorials](tutorials/README.md).
 - Comparing tools? See the [capability matrix](03-platform-comparison.md).
 
 ## Related

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -1,0 +1,38 @@
+# 📖 Understudy Tutorials
+
+Hands-on, step-by-step guides that walk you through **every feature**
+Understudy provides on each platform. All tutorials use the same example
+project (TaskFlow — a task management API) so you can compare workflows
+side by side.
+
+## Available tutorials
+
+| # | Platform | What you'll learn |
+|---|---|---|
+| 1 | [GitHub Copilot CLI](copilot-cli-tutorial.md) | `/agent`, `/instructions`, `/model`, sub-agents, `/compact`, guardrails, session flow, `--add-member`, caveman |
+| 2 | [VS Code Copilot](vscode-copilot-tutorial.md) | Auto-applied `applyTo` instructions, prompt files, `#file:` context, model picker, guardrails, caveman compress/restore |
+| 3 | [Claude Code](claude-code-tutorial.md) | Agents, slash commands, deny list, PreToolUse hook, per-agent model, statusline, caveman |
+| 4 | [Cursor](cursor-tutorial.md) | Rules (MDC), agent panel, 4 rule types, glob auto-attach, commands, guardrails, caveman |
+
+## The example project: TaskFlow
+
+All tutorials build the same project so you can see how the same task
+flows differently across platforms:
+
+- **TaskFlow** — a REST API for task management
+- **Stack:** Node.js + Express + PostgreSQL + Docker
+- **Features:** User auth (JWT), CRUD tasks, assignment, filtering
+
+## How to use these tutorials
+
+1. Pick the platform you use most and follow its tutorial start to finish.
+2. If you use multiple platforms, read the
+   [Cross-Platform Workflows](../08-cross-platform-workflows.md) chapter
+   after completing at least one tutorial.
+3. Each tutorial is self-contained — you don't need to do them in order.
+
+## Prerequisites
+
+- Understudy installed (`curl -fsSL ... | bash` or manual clone)
+- The AI tool for your chosen platform installed and configured
+- A terminal with `bash ≥ 4` (for the wizard)

--- a/docs/tutorials/claude-code-tutorial.md
+++ b/docs/tutorials/claude-code-tutorial.md
@@ -1,0 +1,664 @@
+# Tutorial: Claude Code — Full Feature Walkthrough
+
+> A hands-on guide that walks you through **every feature** Understudy
+> provides for Claude Code, using the same TaskFlow project from the
+> previous tutorials.
+
+## Prerequisites
+
+- Anthropic account with the `claude` CLI installed.
+- Understudy installed.
+
+If starting fresh:
+
+```bash
+mkdir taskflow && cd taskflow && git init
+understudy          # select "Claude Code" platform
+claude              # open the project
+```
+
+---
+
+## What makes Claude Code unique?
+
+Claude Code has the **richest enforcement layer** of all platforms:
+
+| Exclusive feature | What it does |
+|---|---|
+| `settings.json` deny list | Claude refuses to read/write protected files |
+| PreToolUse hook | Blocks destructive commands before execution |
+| Per-agent model assignment | Each agent uses a different model automatically |
+| Slash commands | `/project:<name>` invokes pre-built workflows |
+| Statusline (caveman) | Shows real-time token compression savings |
+
+---
+
+## Part 1 — Understanding the generated files
+
+After running `understudy`, your project has:
+
+```
+CLAUDE.md                           ← Always loaded (project context + critical guardrails)
+.claude/
+├── agents/
+│   ├── architect.md                ← Each agent: name, description, model, tools
+│   ├── backend.md
+│   ├── frontend.md
+│   ├── devops.md
+│   ├── security.md
+│   ├── qa.md
+│   ├── git-specialist.md           ← Auto-deployed
+│   └── repo-documenter.md          ← Auto-deployed
+├── commands/
+│   ├── start-session.md            ← /project:start-session
+│   ├── end-session.md              ← /project:end-session
+│   ├── design-feature.md           ← /project:design-feature
+│   ├── security-review.md          ← /project:security-review
+│   └── understudy.md               ← /project:understudy
+├── hooks/
+│   └── guardrails-check.sh         ← PreToolUse hook
+└── settings.json                   ← Deny rules + hook wiring
+docs/
+├── spec.md
+├── decisions.md
+├── session-log.md
+└── team-roster.md
+```
+
+### 1.1 Feature: `CLAUDE.md` — Always-on instructions
+
+Open `CLAUDE.md`. This file is loaded **every session, automatically**. It
+contains:
+
+- Project name, description, stack
+- Team rules (spec-first, documented decisions, traceable sessions)
+- Critical guardrails (security subset)
+- Reference to the full agent roster
+
+You never need to ask Claude to read it — it's always in context.
+
+### 1.2 Feature: Agent files with model assignment
+
+Open `.claude/agents/architect.md`:
+
+```yaml
+---
+name: architect
+description: "Solutions Architect — designs systems, evaluates trade-offs"
+model: claude-opus-4
+tools: [read, edit, bash]
+---
+```
+
+The **model** field means: when you invoke the architect, Claude
+automatically uses Opus. The backend agent uses Sonnet. You never need to
+manually switch models.
+
+### 1.3 Feature: `settings.json` — Deny list
+
+Open `.claude/settings.json`. It contains entries like:
+
+```json
+{
+  "deny": [
+    ".env",
+    ".env.*",
+    "secrets/**",
+    "**/*.key",
+    "**/*.pem"
+  ]
+}
+```
+
+Claude will **refuse** to read or write any file matching these patterns.
+Even if you explicitly ask, it won't comply.
+
+---
+
+## Part 2 — Starting a session
+
+### 2.1 Feature: `/project:start-session`
+
+```text
+You: /project:start-session
+```
+
+Claude reads `docs/spec.md`, `docs/decisions.md`, `docs/session-log.md`
+and `docs/team-roster.md`, then provides:
+
+- Current project status
+- Last session summary
+- Open items
+- Suggested next steps
+
+Since the project is new, it reports empty docs and suggests writing a spec.
+
+### 2.2 Feature: `/project:understudy` — Discover capabilities
+
+Not sure what's available? Ask:
+
+```text
+You: /project:understudy
+```
+
+Claude explains all available agents, commands, guardrails and the
+recommended workflow. Useful for onboarding new team members.
+
+---
+
+## Part 3 — Designing with agents
+
+### 3.1 Feature: Invoke agent by name
+
+```text
+You: Use the architect agent to design a REST API for task management.
+     Features: user auth (JWT), CRUD tasks, assignment, filtering.
+     Write the spec in docs/spec.md.
+```
+
+Claude switches to the architect persona (Opus model) and:
+1. Asks clarifying questions
+2. Writes a formal spec in `docs/spec.md`
+
+### 3.2 Feature: `/project:design-feature`
+
+For a more structured approach:
+
+```text
+You: /project:design-feature
+```
+
+Claude (as Architect) follows the 8-step design process:
+1. Requirements clarification
+2. Constraint identification
+3. 2-3 alternatives with trade-offs
+4. Recommendation with justification
+5. ADR in `docs/decisions.md`
+6. Mermaid architecture diagram
+7. Security consultation
+8. Implementation plan
+
+```text
+Claude: What feature would you like to design?
+You: A notification system — email users when tasks are assigned or
+     due dates approach (24h before).
+```
+
+Result: ADR-0002 in `docs/decisions.md` with full rationale.
+
+### 3.3 Feature: Per-agent model switching
+
+Notice you didn't run `/model` at any point. The architect's frontmatter
+says `model: claude-opus-4`, so Claude uses Opus automatically for design.
+When you invoke the backend agent later, it switches to Sonnet.
+
+This is **exclusive to Claude Code** — no other platform supports this.
+
+---
+
+## Part 4 — Security: three layers of protection
+
+### 4.1 Layer 1: Instructions (CLAUDE.md)
+
+Critical guardrails are embedded directly in `CLAUDE.md`. They are always
+in context, always respected:
+
+- No secrets in code
+- No destructive operations without confirmation
+- Spec-first development
+- Parameterized queries only
+
+### 4.2 Layer 2: Deny list (settings.json)
+
+Try to read a secret file:
+
+```text
+You: Show me the contents of .env
+```
+
+Claude refuses:
+
+> I cannot read `.env` — it's in the deny list in `.claude/settings.json`.
+> This file likely contains secrets. If you need to reference environment
+> variables, check `.env.example` instead.
+
+**Try writing to a protected path:**
+
+```text
+You: Create a file called secrets/api-keys.json with our API keys.
+```
+
+Claude refuses again — the deny list blocks both reads and writes.
+
+### 4.3 Layer 3: PreToolUse hook (guardrails-check.sh)
+
+This is Claude Code's most powerful safety feature. Before **every tool
+call**, the hook runs and checks the command against destructive patterns.
+
+**The hook blocks commands like:**
+
+| Blocked pattern | Example |
+|---|---|
+| `rm -rf` | `rm -rf /` or `rm -rf node_modules` (with flag) |
+| `DROP TABLE` / `DROP DATABASE` | SQL destructive operations |
+| `terraform destroy` | Infrastructure destruction |
+| `kubectl delete namespace` | Kubernetes resource deletion |
+| `git push --force` | Force-pushing to remote |
+| `docker system prune` | Bulk container/image removal |
+
+**Exercise — Trigger the hook:**
+
+```text
+You: Run: rm -rf src/
+```
+
+The hook intercepts and blocks:
+
+> ⚠️ BLOCKED by guardrails hook: destructive command detected (`rm -rf`).
+> This requires explicit PM confirmation. Please confirm you want to
+> delete the entire src/ directory, or suggest an alternative.
+
+### 4.4 How the hook works internally
+
+Open `.claude/hooks/guardrails-check.sh`:
+
+```bash
+#!/usr/bin/env bash
+# PreToolUse hook — blocks destructive operations
+
+DESTRUCTIVE_PATTERNS=(
+  "rm -rf"
+  "rm -r /"
+  "DROP TABLE"
+  "DROP DATABASE"
+  "terraform destroy"
+  "kubectl delete"
+  "git push --force"
+  "git push -f"
+  "docker system prune"
+  # ... more patterns
+)
+```
+
+The hook:
+1. Reads the command Claude is about to execute
+2. Checks it against `DESTRUCTIVE_PATTERNS`
+3. If matched → exits with code 1 (blocks execution)
+4. If clean → exits with code 0 (allows execution)
+
+### 4.5 Customizing the hook
+
+Add your own patterns:
+
+```bash
+DESTRUCTIVE_PATTERNS=(
+  # ... existing patterns ...
+  "npm publish"           # prevent accidental publishes
+  "aws s3 rm --recursive" # prevent S3 bucket wipes
+  "TRUNCATE"              # prevent table truncation
+)
+```
+
+---
+
+## Part 5 — Implementation
+
+### 5.1 Invoke the backend agent
+
+```text
+You: Use the backend agent to implement the task API following ADR-0001.
+     Set up:
+     - Express project structure
+     - Database schema with Prisma
+     - Auth endpoints (register, login, refresh)
+     - Task CRUD endpoints
+     - Input validation with Zod
+     - Error handling middleware
+     - Dockerfile + docker-compose.yml
+```
+
+Claude switches to the backend persona (Sonnet model) and implements
+everything. Because `CLAUDE.md` is always loaded, it follows the team
+rules automatically.
+
+### 5.2 Combine agents in a single session
+
+Unlike Copilot CLI, you don't need to restart or use `/agent`. Just tell
+Claude which agent to use:
+
+```text
+You: Now use the devops agent to add a GitHub Actions workflow with:
+     - Lint, unit tests, integration tests (PostgreSQL service)
+     - Build and push Docker image to GHCR
+     - Deploy to staging on PR merge
+```
+
+Claude switches persona seamlessly. The context (all files it created
+earlier) remains available.
+
+---
+
+## Part 6 — Slash commands
+
+### 6.1 Feature: `/project:security-review`
+
+Before committing:
+
+```text
+You: /project:security-review
+```
+
+Claude (as Security, model: Opus) reviews all recent changes:
+
+- JWT implementation review
+- Input validation completeness
+- SQL injection surface (parameterized queries check)
+- Secrets in code (none, good)
+- Authorization logic (can user X access user Y's tasks?)
+- Rate limiting recommendations
+
+### 6.2 Feature: `/project:end-session`
+
+```text
+You: /project:end-session
+```
+
+Claude updates `docs/session-log.md`:
+
+```markdown
+## Session — 2026-05-12
+
+### Completed
+- Wrote spec (docs/spec.md)
+- Designed architecture (ADR-0001)
+- Implemented auth + task CRUD
+- Docker setup
+- CI/CD pipeline
+- Security review passed
+
+### Decisions
+- ADR-0001: Express + Prisma (type safety, DX)
+
+### Next steps
+- Notification system (ADR-0002)
+- E2E tests
+- Production deployment
+
+### Blockers
+- None
+```
+
+### 6.3 Feature: Creating custom commands
+
+Add any file to `.claude/commands/`:
+
+```markdown
+---
+name: weekly-report
+description: "Summarize the week from session-log.md"
+---
+
+Read docs/session-log.md for the last 7 days and produce a
+stakeholder-level report: achievements, risks, blockers, next steps.
+```
+
+Invoke it immediately:
+
+```text
+You: /project:weekly-report
+```
+
+More ideas for custom commands:
+
+| Command | Purpose |
+|---|---|
+| `db-migrate` | Generate and run Prisma migrations |
+| `code-review` | Review staged changes against coding standards |
+| `update-docs` | Sync README and API docs with current code |
+| `dependency-check` | Audit npm packages for vulnerabilities |
+
+---
+
+## Part 7 — Guardrails demonstrations
+
+### 7.1 Security guardrail: No secrets
+
+```text
+You: Add the database connection string directly to config.ts:
+     postgresql://admin:<PASSWORD>@prod-db.example.com/taskflow
+```
+
+Claude refuses:
+
+> 🛡️ Guardrail: Security — No secrets in code. I'll use
+> `process.env.DATABASE_URL` and add the variable to `.env.example`
+> (without real values).
+
+### 7.2 Process guardrail: Spec-first
+
+```text
+You: Add a real-time chat feature to the app. Just implement it, no design.
+```
+
+Claude pushes back:
+
+> 🛡️ Guardrail: Process — Spec-first. A real-time chat feature is a
+> significant addition. I need to:
+> 1. Update docs/spec.md with the requirement
+> 2. Design it (ADR) with trade-offs (WebSocket vs SSE vs polling)
+> 3. Get Security review (new attack surface)
+> 4. Then implement
+>
+> Would you like me to start with the design?
+
+### 7.3 Destructive guardrail: Confirmation required
+
+```text
+You: Drop the users table and recreate it from scratch.
+```
+
+The PreToolUse hook blocks the `DROP TABLE` command:
+
+> ⚠️ BLOCKED: Destructive operation (`DROP TABLE`). This requires PM
+> confirmation. Alternative: I can create a migration that renames the
+> table, creates the new schema, migrates data, then drops the old one.
+
+### 7.4 Scope guardrail: Role boundaries
+
+```text
+You: Use the frontend agent to modify the database schema.
+```
+
+Claude (as Frontend) acknowledges it's not its domain:
+
+> 🛡️ Scope: Database schema is the Backend agent's responsibility.
+> I can describe what schema changes the frontend needs (e.g., a
+> `preferences` column for UI settings), and the backend agent can
+> implement them.
+
+---
+
+## Part 8 — Caveman mode (optional)
+
+### 8.1 Enable caveman
+
+```bash
+understudy --caveman
+```
+
+This deploys:
+- `.claude/agents/caveman.md` — the caveman role agent
+- `.claude/commands/compress.md` — `/project:compress`
+- `.claude/commands/restore.md` — `/project:restore`
+- Hooks: `SessionStart` + `UserPromptSubmit` (reinforcement)
+- Statusline script showing compression savings
+
+### 8.2 Feature: `/project:compress`
+
+Compress a verbose Markdown file:
+
+```text
+You: /project:compress docs/decisions.md
+```
+
+The compressor:
+1. Backs up `docs/decisions.md` → `docs/decisions.original.md`
+2. Rewrites the file in caveman style (drops filler, keeps code/paths)
+3. Reports token savings (typically 30-50%)
+
+### 8.3 Feature: `/project:restore`
+
+Restore the original:
+
+```text
+You: /project:restore docs/decisions.md
+```
+
+Restores from the `.original.md` backup.
+
+### 8.4 Feature: Statusline (Claude Code exclusive)
+
+With caveman enabled, Claude's statusline shows real-time stats:
+
+```
+🐉 caveman | saved: 847 tokens (38%) | session: 12.4k tokens
+```
+
+This is exclusive to Claude Code — no other platform has a statusline.
+
+### 8.5 Feature: Reinforcement hooks
+
+The `SessionStart` hook reminds Claude to use caveman style at the
+beginning of every session. The `UserPromptSubmit` hook reinforces it on
+every message. This means caveman stays active without you needing to
+remind it.
+
+---
+
+## Part 9 — Advanced patterns
+
+### 9.1 Multi-agent workflow in one session
+
+```text
+You: Let's build the notification feature end-to-end.
+
+     1. Use the architect agent to design it (ADR-0002 already exists,
+        just verify it's still valid)
+     2. Use the security agent to review the design for risks
+     3. Use the backend agent to implement the queue + email service
+     4. Use the qa agent to write tests
+     5. Use the devops agent to add Redis to docker-compose and CI
+```
+
+Claude executes each step in sequence, switching models as appropriate:
+- Architect (Opus) → Security (Opus) → Backend (Sonnet) → QA (Sonnet) → DevOps (Sonnet)
+
+### 9.2 Extending the deny list
+
+Need to protect more files?
+
+Edit `.claude/settings.json`:
+
+```json
+{
+  "deny": [
+    ".env",
+    ".env.*",
+    "secrets/**",
+    "**/*.key",
+    "**/*.pem",
+    "terraform.tfstate",
+    "*.tfvars",
+    "credentials.json"
+  ]
+}
+```
+
+### 9.3 Adding new agents
+
+Create `.claude/agents/dba.md`:
+
+```yaml
+---
+name: dba
+description: "Database Administrator — schema design, migrations, performance"
+model: claude-sonnet-4
+tools: [read, edit, bash]
+---
+
+# DBA — Database Administrator
+
+## Identity
+You are the Database Administrator of the Understudy team.
+
+## Expertise
+- PostgreSQL: indexing, partitioning, query optimization
+- Migrations: zero-downtime schema changes
+- Performance: EXPLAIN ANALYZE, connection pooling
+- Backup and recovery strategies
+
+## How you work
+1. Read docs/spec.md for data requirements
+2. Design schemas with proper normalization
+3. Write migrations that are reversible
+4. Add appropriate indexes
+5. Document decisions in docs/decisions.md
+```
+
+Invoke immediately:
+
+```text
+You: Use the dba agent to optimize the tasks query with proper indexing.
+```
+
+---
+
+## Part 10 — Claude Code vs other platforms
+
+| Feature | Claude Code | Copilot CLI | VS Code | Cursor |
+|---|---|---|---|---|
+| Auto-loaded instructions | ✅ CLAUDE.md | ✅ copilot-instructions.md | ✅ Same | ✅ Rules |
+| Per-agent model | ✅ Automatic | ❌ Manual `/model` | ❌ Manual | ✅ Frontmatter |
+| Deny list (file protection) | ✅ settings.json | ❌ | ❌ | ❌ |
+| PreToolUse hook | ✅ guardrails-check.sh | ❌ | ❌ | ❌ |
+| Slash commands | ✅ `/project:name` | ❌ | ✅ Prompt files | ✅ Commands |
+| Sub-agents (parallel) | ❌ | ✅ | ❌ | ❌ |
+| Auto-apply by file type | ❌ | ❌ | ✅ `applyTo` | ✅ `globs` |
+| Caveman statusline | ✅ | ❌ | ❌ | ❌ |
+
+---
+
+## Quick reference card
+
+| Feature | How to use |
+|---|---|
+| Start session | `/project:start-session` |
+| End session | `/project:end-session` |
+| Design feature | `/project:design-feature` |
+| Security review | `/project:security-review` |
+| Discover capabilities | `/project:understudy` |
+| Invoke agent | "Use the `<name>` agent to..." |
+| List agents | `/agents` (native Claude command) |
+| Change model | `/model` (or let per-agent model handle it) |
+| Compress tokens | `/compact` (native) |
+| Protected files | Edit `.claude/settings.json` deny list |
+| Custom command | Add `.md` file to `.claude/commands/` |
+| Custom agent | Add `.md` file to `.claude/agents/` |
+| Extend guardrails hook | Edit `.claude/hooks/guardrails-check.sh` |
+| Caveman compress | `/project:compress` |
+| Caveman restore | `/project:restore` |
+
+---
+
+## Next steps
+
+- Try the [Cursor tutorial](cursor-tutorial.md) — rules, agents, MDC
+  format, glob-based auto-attach.
+- Read [Cross-Platform Workflows](../08-cross-platform-workflows.md) to
+  combine Claude Code with other tools in the same project.
+- See [Configuration Reference](../09-configuration.md) for model and
+  guardrails customization.
+
+---
+
+[← VS Code tutorial](vscode-copilot-tutorial.md) · [Back to tutorials index](README.md) · [Next: Cursor →](cursor-tutorial.md)

--- a/docs/tutorials/copilot-cli-tutorial.md
+++ b/docs/tutorials/copilot-cli-tutorial.md
@@ -1,0 +1,577 @@
+# Tutorial: GitHub Copilot CLI — Full Feature Walkthrough
+
+> A hands-on guide that walks you through **every feature** Understudy
+> provides for Copilot CLI, using a real-world example project.
+
+## The example project: TaskFlow API
+
+Throughout this tutorial you will build **TaskFlow** — a task management REST
+API with user authentication. This is intentionally simple so you can focus
+on learning the AI workflow, not the domain.
+
+**Stack:** Node.js + Express + PostgreSQL  
+**Goal:** A CRUD API for tasks with user auth, deployed with Docker.
+
+---
+
+## Part 1 — Setup and deployment
+
+### 1.1 Create the project folder
+
+```bash
+mkdir taskflow && cd taskflow
+git init
+```
+
+### 1.2 Deploy Understudy
+
+```bash
+understudy
+```
+
+The wizard asks 9 questions. Answer like this for the tutorial:
+
+| # | Question | Answer |
+|---|---|---|
+| 1 | Project name | `taskflow` |
+| 2 | Short description | `Task management REST API` |
+| 3 | Project manager | Your name |
+| 4 | Tech stack | `Node.js + Express + PostgreSQL + Docker` |
+| 5 | Repository URL | `https://github.com/you/taskflow` |
+| 6 | Guardrails mode | `split` (recommended) |
+| 7 | Platforms | `Copilot` |
+| 8 | Git: commit files? | `y` |
+| 9 | Git: local-only config? | `n` |
+
+> **Shortcut:** If you already have a repo with a `package.json` and a
+> remote configured, use `understudy --here` to auto-infer all values.
+
+### 1.3 Verify the generated files
+
+```bash
+ls -la
+```
+
+You should see:
+
+```
+AGENTS.md                                 ← Team definition
+.github/copilot-instructions.md           ← Global instructions (always active)
+.github/instructions/
+    architect.instructions.md
+    backend.instructions.md
+    frontend.instructions.md
+    devops.instructions.md
+    security.instructions.md
+    qa-engineer.instructions.md
+    guardrails.instructions.md            ← Full guardrails (always active)
+    git-specialist.instructions.md        ← Auto-deployed
+    repo-documenter.instructions.md       ← Auto-deployed
+.github/prompts/
+    start-session.prompt.md
+    end-session.prompt.md
+    design-feature.prompt.md
+    security-review.prompt.md
+    understudy.prompt.md
+docs/
+    spec.md
+    decisions.md
+    session-log.md
+    team-roster.md
+```
+
+> **What each file does:**
+>
+> - `AGENTS.md` — Copilot reads this automatically. It defines the agents
+>   you can select with `/agent`.
+> - `.github/copilot-instructions.md` — Loaded automatically in every
+>   conversation. Contains project context + critical guardrails.
+> - `.github/instructions/*.instructions.md` — Detailed per-role
+>   instructions. Toggled with `/instructions`.
+> - `docs/*.md` — Persistent memory. The AI reads/writes these to maintain
+>   context across sessions.
+
+---
+
+## Part 2 — Starting your first session
+
+### 2.1 Open Copilot CLI
+
+```bash
+copilot
+```
+
+Copilot loads `AGENTS.md` and `.github/copilot-instructions.md` automatically.
+You'll notice it already knows your project name, stack and team rules.
+
+### 2.2 Feature: `/agent` — See available agents
+
+```text
+You: /agent
+```
+
+Copilot shows the list of agents from `AGENTS.md`:
+
+```
+Available agents:
+  • Architect    — Solutions Architect
+  • Backend      — Backend Developer
+  • Frontend     — Frontend Developer
+  • DevOps       — DevOps Engineer
+  • Security     — Security Expert
+  • QA           — QA Engineer
+```
+
+### 2.3 Feature: Start a session (reading context)
+
+```text
+You: Read docs/session-log.md, docs/spec.md and docs/decisions.md.
+     Summarize the current state of the project and suggest next steps.
+```
+
+Since the project is new, the agent will tell you the docs are empty and
+suggest writing a spec first. This is exactly what Understudy's
+**spec-first** rule enforces.
+
+---
+
+## Part 3 — Designing with the Architect
+
+### 3.1 Feature: `/agent Architect` — Switch agent
+
+```text
+You: /agent Architect
+```
+
+Copilot adopts the Architect's personality: system design, trade-offs, ADRs.
+
+### 3.2 Feature: `/instructions` — Load detailed role instructions
+
+```text
+You: /instructions
+```
+
+Select `architect.instructions.md`. This loads the Architect's full
+expertise list, working process and output standards into context.
+
+### 3.3 Feature: `/model` — Choose the right model
+
+```text
+You: /model
+```
+
+Select **Claude Opus** (or the most capable model available). The Architect
+benefits from deeper reasoning for system design.
+
+> **Rule of thumb from `understudy.yaml`:**
+> - Architect / Security → Opus (complex reasoning)
+> - Backend / Frontend → Sonnet (good speed/quality balance)
+> - Quick tasks → Haiku (fast and cheap)
+
+### 3.4 Write the spec
+
+```text
+You: I need a REST API for task management. Features:
+     - User registration and login (JWT)
+     - CRUD tasks (title, description, status, due date)
+     - Assign tasks to users
+     - Filter by status, assignee, due date
+     - PostgreSQL database
+     - Docker for deployment
+
+     Write this as a formal spec in docs/spec.md following the team's
+     spec format.
+```
+
+The Architect writes `docs/spec.md` with requirements, constraints, NFRs
+and acceptance criteria.
+
+### 3.5 Design the architecture (ADR)
+
+```text
+You: Propose 2-3 architectural alternatives for this API.
+     Evaluate trade-offs (complexity, scalability, team familiarity).
+     Recommend one and document it as ADR-0001 in docs/decisions.md.
+```
+
+The Architect produces:
+- Alternative A: Express + Sequelize ORM
+- Alternative B: Express + raw SQL (pg)
+- Alternative C: Fastify + Prisma
+
+It recommends one, writes `docs/decisions.md` with the ADR in the standard
+format: Title, Status, Context, Options, Decision, Consequences.
+
+---
+
+## Part 4 — Security review
+
+### 4.1 Switch to Security agent
+
+```text
+You: /agent Security
+You: /instructions
+```
+
+Select `security.instructions.md`.
+
+### 4.2 Feature: Security threat modeling
+
+```text
+You: Review the architecture in docs/decisions.md ADR-0001.
+     Produce a threat model covering:
+     - Authentication flows (JWT)
+     - Input validation
+     - SQL injection surface
+     - Authorization (can user X edit user Y's tasks?)
+     - Secrets management
+     Add security requirements to docs/spec.md.
+```
+
+The Security agent reviews the design and adds constraints like:
+- JWT must expire in ≤ 1h
+- Refresh tokens stored httpOnly
+- Parameterized queries only (no string concatenation)
+- Rate limiting on auth endpoints
+- Input validation with Joi/Zod
+
+---
+
+## Part 5 — Implementation with sub-agents
+
+### 5.1 Feature: Sub-agents (parallel work)
+
+This is one of Copilot CLI's most powerful features. You can ask it to
+split work across multiple internal agents that run in parallel.
+
+```text
+You: Implement TaskFlow following ADR-0001 and the security requirements.
+     Split the work:
+
+     Sub-agent 1 (Backend):
+     - Set up Express project structure
+     - Database schema (migrations)
+     - Auth endpoints (register, login, refresh)
+     - Task CRUD endpoints
+     - Input validation with Zod
+     - Error handling middleware
+
+     Sub-agent 2 (Frontend):
+     - Not applicable yet — skip for now
+
+     Sub-agent 3 (DevOps):
+     - Dockerfile
+     - docker-compose.yml (app + postgres)
+     - .env.example
+
+     Both must follow docs/decisions.md ADR-0001.
+```
+
+Copilot launches internal task agents that work in parallel. You'll see
+them produce files simultaneously.
+
+### 5.2 Switch to Backend for refinement
+
+```text
+You: /agent Backend
+You: /instructions
+```
+
+Select `backend.instructions.md`.
+
+```text
+You: Review the generated code. Ensure:
+     - All endpoints have input validation
+     - Error responses follow a consistent format
+     - Database queries use parameterized statements
+     - Auth middleware protects /tasks routes
+```
+
+### 5.3 Feature: `/diff` — Review changes
+
+```text
+You: /diff
+```
+
+Shows all pending file modifications. Review before accepting.
+
+---
+
+## Part 6 — QA: Testing
+
+### 6.1 Switch to QA
+
+```text
+You: /agent QA
+You: /instructions
+```
+
+Select `qa-engineer.instructions.md`.
+
+### 6.2 Write tests
+
+```text
+You: Create a test plan for TaskFlow. Then implement:
+     1. Unit tests for auth service (register, login, token validation)
+     2. Unit tests for task CRUD operations
+     3. Integration tests for the full API (using supertest)
+     4. Edge cases: expired tokens, invalid input, unauthorized access
+
+     Use Jest as the test framework.
+```
+
+The QA agent produces:
+- `tests/unit/auth.test.js`
+- `tests/unit/tasks.test.js`
+- `tests/integration/api.test.js`
+- A test plan summary
+
+---
+
+## Part 7 — DevOps: CI/CD
+
+### 7.1 Switch to DevOps
+
+```text
+You: /agent DevOps
+You: /instructions
+```
+
+### 7.2 Add CI pipeline
+
+```text
+You: Create a GitHub Actions workflow for TaskFlow:
+     - Lint (ESLint)
+     - Unit tests
+     - Integration tests (needs PostgreSQL service)
+     - Build Docker image
+     - Push to GHCR on main branch
+
+     Follow the security guardrails (no secrets in code, use GitHub
+     Secrets).
+```
+
+---
+
+## Part 8 — Guardrails in action
+
+### 8.1 What guardrails do
+
+Guardrails are **always active** — Copilot loads them from
+`.github/copilot-instructions.md` (critical subset) and
+`guardrails.instructions.md` (full details).
+
+### 8.2 Try to violate a guardrail
+
+```text
+You: Add a hardcoded database password in the config file.
+     Use a literal string as the password.
+```
+
+The agent will **refuse** and explain:
+
+> ⚠️ Guardrail violation: Security category — "No secrets, no bypass,
+> mandatory input validation". Credentials must come from environment
+> variables or a secrets manager, never hardcoded.
+
+It will suggest using `process.env.DATABASE_PASSWORD` instead.
+
+### 8.3 Try another violation
+
+```text
+You: Delete all migration files and the entire tests/ folder.
+```
+
+The agent will **refuse** or request confirmation:
+
+> ⚠️ Guardrail violation: Destructive operations — "PM confirmation before
+> deleting, purging or revoking". This is a bulk destructive operation.
+> Please confirm with the project manager before proceeding.
+
+### 8.4 Scope guardrail
+
+```text
+You: /agent Frontend
+You: Modify the database schema in src/db/migrations/
+```
+
+The Frontend agent will note that database schema is Backend's domain and
+either defer or ask for justification.
+
+---
+
+## Part 9 — Token management
+
+### 9.1 Feature: `/compact` — Compress conversation
+
+After a long session, your token count increases. Use:
+
+```text
+You: /compact
+```
+
+This compresses the conversation history while preserving key decisions.
+Your actual project state is safe because it lives in `docs/session-log.md`.
+
+### 9.2 Feature: `/context` — Check usage
+
+```text
+You: /context
+```
+
+Shows current token usage and which files are loaded. Useful to understand
+if you're approaching limits.
+
+---
+
+## Part 10 — Ending the session
+
+### 10.1 Update the session log
+
+```text
+You: Update docs/session-log.md with:
+     - What we accomplished today
+     - Decisions made (reference ADR-0001)
+     - Open items / next steps
+     - Any blockers
+```
+
+The agent writes a structured entry:
+
+```markdown
+## Session — 2026-05-12
+
+### Completed
+- Wrote spec (docs/spec.md)
+- Designed architecture (ADR-0001: Express + Prisma)
+- Security review and threat model
+- Implemented auth + task CRUD
+- Docker setup (Dockerfile + docker-compose)
+- Test suite (unit + integration)
+- CI/CD pipeline (GitHub Actions)
+
+### Decisions
+- ADR-0001: Express + Prisma over raw SQL (DX, type safety)
+
+### Next steps
+- Frontend (React)
+- E2E tests
+- Production deployment manifests
+
+### Blockers
+- None
+```
+
+### 10.2 Why this matters
+
+Next time you (or a teammate) start a session, the AI reads
+`session-log.md` and immediately knows the full project history — no need
+to re-explain anything. This is Understudy's **persistent memory**.
+
+---
+
+## Part 11 — Adding team members
+
+### 11.1 Feature: `--add-member`
+
+Need a Data Engineer for analytics pipelines later?
+
+```bash
+understudy --add-member
+```
+
+Choose from the catalog:
+
+```
+Available roles:
+  1) data-engineer
+  2) mobile-engineer
+  3) ml-engineer
+  4) sre
+  5) tech-writer
+  ...
+```
+
+Select one and it's deployed to `.github/instructions/` and added to
+`AGENTS.md`. Next time you open Copilot, `/agent` will show the new member.
+
+### 11.2 Feature: `--create-role`
+
+Need a role that doesn't exist?
+
+```bash
+understudy --create-role
+```
+
+The wizard asks for: name, title, description, expertise areas, motto.
+It generates a `.instructions.md` file in `roles/` for reuse across all
+your projects.
+
+---
+
+## Part 12 — Caveman mode (optional)
+
+### 12.1 What is Caveman?
+
+A token-efficient communication style. The AI drops filler words, articles,
+and unnecessary prose while preserving code, paths and technical accuracy.
+Saves 30-50% tokens per response.
+
+### 12.2 Enable it
+
+```bash
+understudy --caveman
+```
+
+This deploys:
+- `.github/instructions/caveman.instructions.md` (role, `applyTo: "**"`)
+
+### 12.3 Use it
+
+After enabling, the AI's responses become shorter:
+
+**Normal:**
+> I'll create a new Express middleware function that validates the JWT token
+> from the Authorization header and attaches the decoded user payload to
+> the request object.
+
+**Caveman:**
+> Creating JWT middleware → validates Authorization header, attaches decoded
+> user to `req.user`.
+
+Same accuracy, fewer tokens.
+
+---
+
+## Quick reference card
+
+| Feature | Command / Action |
+|---|---|
+| Switch agent | `/agent <name>` |
+| Load role details | `/instructions` → select file |
+| Change model | `/model` → select |
+| Compress tokens | `/compact` |
+| See changes | `/diff` |
+| Check token usage | `/context` |
+| Parallel work | Ask for sub-agents in prompt |
+| Start session | Read `docs/session-log.md`, `spec.md`, `decisions.md` |
+| End session | Update `docs/session-log.md` |
+| Add team member | `understudy --add-member` (in terminal) |
+| Create new role | `understudy --create-role` (in terminal) |
+| Enable caveman | `understudy --caveman` (in terminal) |
+| Guardrails | Always active — no action needed |
+
+---
+
+## Next steps
+
+- Try the [VS Code Copilot tutorial](vscode-copilot-tutorial.md) — same
+  project, different workflow (auto-applied instructions, prompt files).
+- Read [Cross-Platform Workflows](../08-cross-platform-workflows.md) to
+  combine CLI and VS Code in the same project.
+- See [Configuration Reference](../09-configuration.md) to customize
+  models, guardrails mode and role settings.
+
+---
+
+[← Back to tutorials index](README.md) · [Next: VS Code Copilot →](vscode-copilot-tutorial.md)

--- a/docs/tutorials/cursor-tutorial.md
+++ b/docs/tutorials/cursor-tutorial.md
@@ -1,0 +1,695 @@
+# Tutorial: Cursor — Full Feature Walkthrough
+
+> A hands-on guide that walks you through **every feature** Understudy
+> provides for Cursor, using the same TaskFlow project from the previous
+> tutorials.
+
+## Prerequisites
+
+- Cursor installed.
+- Understudy installed.
+
+If starting fresh:
+
+```bash
+mkdir taskflow && cd taskflow && git init
+understudy          # select "Cursor" platform
+cursor .            # open the project
+```
+
+---
+
+## What makes Cursor unique?
+
+Cursor uses two complementary systems that differ from other platforms:
+
+| Concept | What it means |
+|---|---|
+| **Rules** (`.mdc` files) | Global instructions, always active or auto-attached by glob |
+| **Agents** (`.md` files) | Role-based personas invoked from the Agent panel |
+| **Commands** | Slash commands invoked from chat |
+| **Model in frontmatter** | Each agent auto-selects its model (`auto`, `fast`, specific) |
+| **Glob-based auto-attach** | Rules load when you edit matching files (like VS Code's `applyTo`) |
+
+---
+
+## Part 1 — Understanding the generated files
+
+After running `understudy`, your project has:
+
+```
+.cursor/
+├── rules/
+│   ├── understudy-global.mdc      ← Always active (project context + team rules)
+│   └── guardrails.mdc             ← Always active (full guardrails)
+├── agents/
+│   ├── architect.md
+│   ├── backend.md
+│   ├── frontend.md
+│   ├── devops.md
+│   ├── security.md
+│   ├── qa-engineer.md
+│   ├── git-specialist.md           ← Auto-deployed
+│   └── repo-documenter.md          ← Auto-deployed
+└── commands/
+    └── understudy.md               ← /understudy command
+docs/
+├── spec.md
+├── decisions.md
+├── session-log.md
+└── team-roster.md
+```
+
+### 1.1 Feature: Rules (MDC format)
+
+Open `.cursor/rules/understudy-global.mdc`:
+
+```yaml
+---
+description: "Global Understudy project instructions — always active"
+alwaysApply: true
+---
+
+# Project: TaskFlow
+# Description: Task management REST API
+# Stack: Node.js + Express + PostgreSQL + Docker
+# ...
+```
+
+Key: `alwaysApply: true` means this rule is loaded in **every single
+conversation** without you doing anything.
+
+### 1.2 Feature: Guardrails rule
+
+Open `.cursor/rules/guardrails.mdc`:
+
+```yaml
+---
+description: "Understudy guardrails — non-negotiable safety limits"
+alwaysApply: true
+---
+
+# 🛡️ Guardrails
+## 1. Security
+- Never hardcode secrets...
+## 2. Scope
+- Respect file ownership...
+...
+```
+
+Also `alwaysApply: true` — guardrails are always in context.
+
+### 1.3 Feature: Agent files
+
+Open `.cursor/agents/architect.md`:
+
+```yaml
+---
+name: architect
+description: "Solutions Architect — Understudy"
+model: auto
+---
+
+# Architect — Solutions Architect
+
+## Identity
+You are the Solutions Architect...
+
+## Expertise
+- System design, APIs, databases...
+```
+
+The `model` field controls which model Cursor uses when this agent is
+active. Options:
+- `auto` — Cursor's default model
+- `fast` — fastest available model
+- `claude-opus-4` — specific model (if available)
+
+---
+
+## Part 2 — The four types of rules
+
+### 2.1 Always-apply rules
+
+```yaml
+---
+alwaysApply: true
+---
+```
+
+Loaded unconditionally. Used for:
+- Global project instructions (`understudy-global.mdc`)
+- Guardrails (`guardrails.mdc`)
+
+**Cost:** Consumes tokens every session. Keep them concise.
+
+### 2.2 Auto-attached rules (glob-based)
+
+```yaml
+---
+description: "React component standards"
+globs: "src/components/**/*.tsx,src/components/**/*.css"
+---
+```
+
+Loaded only when you edit files matching the glob pattern. This is
+Cursor's equivalent of VS Code's `applyTo`.
+
+**Exercise — Create an auto-attached rule:**
+
+Create `.cursor/rules/backend-standards.mdc`:
+
+```yaml
+---
+description: "Backend coding standards for services"
+globs: "src/services/**/*.ts,src/controllers/**/*.ts"
+---
+
+- Use dependency injection (constructor parameters)
+- All public methods must have JSDoc
+- Error handling: throw typed AppError, never raw Error
+- Database queries: always use parameterized statements
+- Input validation: Zod schemas at the controller boundary
+```
+
+Now when you open any file in `src/services/` or `src/controllers/`, this
+rule activates automatically.
+
+### 2.3 Agent-requested rules
+
+```yaml
+---
+description: "Database migration conventions"
+---
+```
+
+No `alwaysApply`, no `globs` — just a description. Cursor reads the
+description and **decides** whether to apply the rule based on your
+current conversation context.
+
+### 2.4 Manual rules
+
+```yaml
+---
+---
+```
+
+Neither auto-applied nor auto-attached. Only loaded if you explicitly
+reference the rule in chat.
+
+### 2.5 Summary table
+
+| Rule type | Frontmatter | When loaded | Token cost |
+|---|---|---|---|
+| Always | `alwaysApply: true` | Every session | Constant |
+| Auto-attached | `globs: "pattern"` | Matching file open | Per-file |
+| Agent-requested | `description:` only | Cursor decides | On-demand |
+| Manual | Empty frontmatter | You reference it | On-demand |
+
+---
+
+## Part 3 — Using the Agent panel
+
+### 3.1 Feature: Agent panel
+
+In Cursor, open the **Agent panel** (usually in the right sidebar or via
+the command palette). You'll see all agents from `.cursor/agents/`:
+
+```
+Available agents:
+  architect    — Solutions Architect
+  backend      — Backend Developer
+  frontend     — Frontend Developer
+  devops       — DevOps Engineer
+  security     — Security Expert
+  qa-engineer  — QA Engineer
+  git-specialist
+  repo-documenter
+```
+
+### 3.2 Select an agent
+
+Click **architect** in the Agent panel. The chat now uses the Architect's
+personality, expertise and model.
+
+```text
+You: Design a REST API for task management. Users can create, read,
+     update and delete tasks. Tasks have: title, description, status
+     (todo/in-progress/done), due date, assignee.
+     Write the spec in docs/spec.md and an ADR in docs/decisions.md.
+```
+
+The Architect:
+1. Asks clarifying questions about scale, auth, etc.
+2. Proposes 2-3 alternatives
+3. Recommends one
+4. Writes spec + ADR
+
+### 3.3 Switch agents mid-session
+
+Click **security** in the Agent panel:
+
+```text
+You: Review ADR-0001 in docs/decisions.md. Threat model the JWT auth
+     flow and suggest hardening measures.
+```
+
+Click **backend**:
+
+```text
+You: Implement the task API following ADR-0001. Set up Express + Prisma +
+     Zod validation. Include auth middleware.
+```
+
+You can switch agents freely — the conversation context is preserved.
+Each agent uses its configured model automatically.
+
+---
+
+## Part 4 — Commands
+
+### 4.1 Feature: `/understudy` command
+
+```text
+You: /understudy
+```
+
+Cursor explains all available agents, rules, the recommended workflow and
+how to use the system. Good for onboarding.
+
+### 4.2 Creating custom commands
+
+Add a file to `.cursor/commands/`:
+
+**`.cursor/commands/start-session.md`:**
+
+```markdown
+Read docs/session-log.md, docs/spec.md, docs/decisions.md and
+docs/team-roster.md. Summarize:
+- Current project state
+- Last session's work
+- Open items and blockers
+- Suggested next steps
+```
+
+**`.cursor/commands/end-session.md`:**
+
+```markdown
+Update docs/session-log.md with a new entry for today:
+- What was accomplished
+- Decisions made (reference ADRs)
+- Next steps
+- Blockers (if any)
+```
+
+Now you can use:
+
+```text
+You: /start-session
+You: /end-session
+```
+
+### 4.3 More useful custom commands
+
+**`.cursor/commands/design-feature.md`:**
+
+```markdown
+Act as the Architect agent. Follow this process:
+1. Ask what feature to design
+2. Identify constraints (from docs/spec.md)
+3. Propose 2-3 alternatives with trade-offs
+4. Recommend one with justification
+5. Write an ADR in docs/decisions.md
+6. Produce a Mermaid architecture diagram
+```
+
+**`.cursor/commands/security-review.md`:**
+
+```markdown
+Act as the Security agent. Review all recent changes for:
+- Hardcoded secrets
+- SQL injection
+- Missing input validation
+- Broken authentication/authorization
+- PII exposure
+- Missing rate limiting
+Report findings with severity (Critical/High/Medium/Low).
+```
+
+---
+
+## Part 5 — Guardrails in action
+
+### 5.1 Always-active protection
+
+Since `guardrails.mdc` uses `alwaysApply: true`, the guardrails are
+enforced in every single conversation, regardless of which agent is active.
+
+### 5.2 Exercise: Security guardrail
+
+Select the **backend** agent and ask:
+
+```text
+You: Store the JWT secret directly in the code:
+     const JWT_SECRET = "<REDACTED>"
+```
+
+Cursor refuses:
+
+> 🛡️ Guardrail violation: Security — "No secrets in code". The JWT
+> secret must come from an environment variable. I'll use
+> `process.env.JWT_SECRET` and add it to `.env.example`.
+
+### 5.3 Exercise: Process guardrail
+
+```text
+You: Add a WebSocket real-time feature. Just code it, skip the design.
+```
+
+Cursor pushes back:
+
+> 🛡️ Guardrail: Process — "Spec-first". Real-time communication is a
+> significant architectural decision. I should:
+> 1. Update docs/spec.md
+> 2. Create an ADR evaluating WebSocket vs SSE vs polling
+> 3. Get Security review (new attack surface: WebSocket hijacking)
+>
+> Shall I start with the design?
+
+### 5.4 Exercise: Destructive guardrail
+
+```text
+You: Delete the entire tests/ directory and the migrations/ folder.
+```
+
+Cursor flags:
+
+> 🛡️ Guardrail: Destructive operations — requires PM confirmation.
+> This would delete all tests and database migrations. Are you sure?
+> Alternative: I can archive them or create a clean branch.
+
+### 5.5 Exercise: Scope guardrail
+
+Select the **frontend** agent:
+
+```text
+You: Modify the database migration to add a new column.
+```
+
+The Frontend agent defers:
+
+> 🛡️ Scope: Database migrations are the Backend agent's responsibility.
+> I can describe what data the frontend needs (e.g., a `theme` field
+> for user preferences), and the backend agent can implement the
+> migration.
+
+---
+
+## Part 6 — Creating custom rules
+
+### 6.1 Project-specific coding standards
+
+Create `.cursor/rules/api-conventions.mdc`:
+
+```yaml
+---
+description: "REST API conventions for TaskFlow"
+globs: "src/controllers/**/*.ts,src/routes/**/*.ts"
+---
+
+# API Conventions
+
+- All endpoints return `{ data, error, meta }` envelope
+- HTTP status codes: 200 (ok), 201 (created), 400 (validation),
+  401 (unauthenticated), 403 (forbidden), 404 (not found), 500 (server)
+- Pagination: `?page=1&limit=20` → meta includes `total`, `pages`
+- Sorting: `?sort=created_at&order=desc`
+- Filtering: `?status=active&assignee=user-123`
+- All dates in ISO 8601 (UTC)
+- Idempotency key header for POST/PUT: `X-Idempotency-Key`
+```
+
+This activates only when editing controller or route files.
+
+### 6.2 Testing standards
+
+Create `.cursor/rules/testing-standards.mdc`:
+
+```yaml
+---
+description: "Testing standards for TaskFlow"
+globs: "tests/**/*.ts,**/*.test.ts,**/*.spec.ts"
+---
+
+# Testing Standards
+
+- Framework: Jest + Supertest
+- Arrange-Act-Assert pattern
+- One assertion per test (prefer)
+- Mock external services (database, email, etc.)
+- Integration tests use a test database (docker-compose.test.yml)
+- Naming: `describe('<module>') → it('should <behavior>')`
+- Coverage target: 80% lines, 90% branches for critical paths
+```
+
+### 6.3 Documentation standards
+
+Create `.cursor/rules/docs-standards.mdc`:
+
+```yaml
+---
+description: "Documentation standards"
+globs: "docs/**/*.md,README.md"
+---
+
+# Documentation Standards
+
+- ADRs follow: Title, Status, Context, Options, Decision, Consequences
+- Session log entries: date, completed, decisions, next steps, blockers
+- Spec sections: overview, requirements (functional + NFR), constraints,
+  acceptance criteria, out of scope
+- Use Mermaid for diagrams
+- Keep language concise — no filler prose
+```
+
+---
+
+## Part 7 — Caveman mode (optional)
+
+### 7.1 Enable caveman
+
+```bash
+understudy --caveman --caveman-commands
+```
+
+This deploys:
+- `.cursor/agents/caveman.md` — the caveman role agent
+- `.cursor/commands/compress.md` — `/compress` command
+- `.cursor/commands/restore.md` — `/restore` command
+- `.cursor/rules/00-caveman-active.mdc` — reinforcement rule (`alwaysApply`)
+
+### 7.2 Feature: Reinforcement rule
+
+Open `.cursor/rules/00-caveman-active.mdc`:
+
+```yaml
+---
+description: "Caveman mode active — use token-efficient style"
+alwaysApply: true
+---
+
+Respond in caveman style: drop filler words, articles, unnecessary prose.
+Keep all code, paths, URLs, technical terms intact. Prioritize clarity
+over politeness.
+```
+
+Because `alwaysApply: true`, this is active in **every** conversation —
+Cursor always responds concisely.
+
+### 7.3 Feature: `/compress` command
+
+```text
+You: /compress docs/decisions.md
+```
+
+Compresses the file in-place (with backup). Token savings: 30-50%.
+
+### 7.4 Feature: `/restore` command
+
+```text
+You: /restore docs/decisions.md
+```
+
+Restores from `.original.md` backup.
+
+### 7.5 Caveman in practice
+
+**Without caveman:**
+> I'll implement the authentication middleware. This middleware will
+> extract the JWT token from the Authorization header, verify it using
+> the secret key from the environment variables, and attach the decoded
+> user payload to the request object for use in downstream handlers.
+
+**With caveman:**
+> Implementing auth middleware → extracts JWT from `Authorization` header,
+> verifies with `process.env.JWT_SECRET`, attaches decoded user to `req.user`.
+
+Same technical accuracy, 40% fewer tokens.
+
+---
+
+## Part 8 — Advanced patterns
+
+### 8.1 Combining rules and agents
+
+The power of Cursor is that rules and agents stack:
+
+```
+Active context = always-apply rules + matching glob rules + active agent
+```
+
+So when you select the **backend** agent and open `src/services/auth.ts`:
+
+1. `understudy-global.mdc` loads (always)
+2. `guardrails.mdc` loads (always)
+3. `backend-standards.mdc` loads (glob matches `src/services/**`)
+4. `api-conventions.mdc` loads (if in `src/controllers/`)
+5. Backend agent personality loads (from agent panel)
+
+This gives incredibly precise, context-aware responses.
+
+### 8.2 Model strategy
+
+Configure models strategically in agent frontmatter:
+
+```yaml
+# architect.md — needs deep reasoning
+model: claude-opus-4
+
+# backend.md — good balance
+model: auto
+
+# frontend.md — good balance
+model: auto
+
+# qa-engineer.md — fast iteration on tests
+model: fast
+```
+
+### 8.3 Adding new agents
+
+Create `.cursor/agents/tech-lead.md`:
+
+```yaml
+---
+name: tech-lead
+description: "Tech Lead — code review, mentoring, standards"
+model: auto
+---
+
+# Tech Lead
+
+## Identity
+You are the Tech Lead. You review code, enforce standards and mentor the team.
+
+## How you work
+1. Review code for correctness, performance and maintainability
+2. Check adherence to project conventions (see rules)
+3. Suggest improvements with explanations (teach, don't just fix)
+4. Approve or request changes with clear reasoning
+```
+
+It appears in the Agent panel immediately.
+
+### 8.4 Multi-file glob patterns
+
+```yaml
+globs: "src/**/*.ts,!src/**/*.test.ts,!src/**/*.spec.ts"
+```
+
+The `!` prefix excludes patterns. This rule applies to all TypeScript
+source files **except** tests.
+
+---
+
+## Part 9 — Cursor vs other platforms
+
+| Feature | Cursor | Claude Code | VS Code | Copilot CLI |
+|---|---|---|---|---|
+| Auto-applied global rules | ✅ `alwaysApply` | ✅ CLAUDE.md | ✅ copilot-instructions | ✅ Same |
+| Glob-based rule loading | ✅ `.mdc` globs | ❌ | ✅ `applyTo` | ❌ |
+| Agent panel | ✅ Visual | ❌ (by name in chat) | ❌ | `/agent` |
+| Per-agent model | ✅ Frontmatter | ✅ Frontmatter | ❌ | ❌ |
+| Commands | ✅ `.cursor/commands/` | ✅ `.claude/commands/` | ✅ `.github/prompts/` | ❌ |
+| File protection (deny) | ❌ | ✅ settings.json | ❌ | ❌ |
+| PreToolUse hook | ❌ | ✅ guardrails-check.sh | ❌ | ❌ |
+| Sub-agents (parallel) | ❌ | ❌ | ❌ | ✅ |
+| Caveman reinforcement | ✅ alwaysApply rule | ✅ Real hooks | ⚠️ Marker block | ❌ |
+| Caveman statusline | ❌ | ✅ Claude only | ❌ | ❌ |
+
+**Cursor's strengths:** Visual agent panel, flexible rule system (4 types),
+glob-based auto-attach, clean MDC format.
+
+---
+
+## Quick reference card
+
+| Feature | How to use |
+|---|---|
+| Select agent | Agent panel → click name |
+| Always-apply rule | `alwaysApply: true` in `.mdc` frontmatter |
+| Auto-attach rule | `globs: "pattern"` in `.mdc` frontmatter |
+| Invoke command | `/command-name` in chat |
+| Create rule | Add `.mdc` to `.cursor/rules/` |
+| Create agent | Add `.md` to `.cursor/agents/` |
+| Create command | Add `.md` to `.cursor/commands/` |
+| Guardrails | Always active (no action needed) |
+| Model per agent | `model:` field in agent frontmatter |
+| Caveman compress | `/compress` command |
+| Caveman restore | `/restore` command |
+| Exclude from glob | Use `!pattern` prefix |
+
+---
+
+## Exercise: Full workflow
+
+Try this complete workflow in Cursor:
+
+```text
+1. /start-session (custom command — see Part 4.2)
+
+2. Agent panel → architect
+   "Design a password reset flow. Write ADR-0003."
+
+3. Agent panel → security
+   "Review ADR-0003. What are the risks? Add mitigations."
+
+4. Agent panel → backend
+   "Implement the password reset: endpoint, email token, expiry."
+
+5. Agent panel → qa-engineer
+   "Write tests: valid reset, expired token, invalid email, rate limiting."
+
+6. Agent panel → devops
+   "Add the SMTP config to docker-compose and CI secrets."
+
+7. /end-session (custom command)
+```
+
+Each step uses the right agent with the right model, and the always-apply
+rules (guardrails + global) stay active throughout.
+
+---
+
+## Next steps
+
+- Read [Cross-Platform Workflows](../08-cross-platform-workflows.md) to
+  combine Cursor with Claude Code or VS Code.
+- See [Configuration Reference](../09-configuration.md) for model and
+  guardrails customization.
+- Try [Caveman Mode](../10-caveman-mode.md) for deep details on the
+  compression system.
+
+---
+
+[← Claude Code tutorial](claude-code-tutorial.md) · [Back to tutorials index](README.md)

--- a/docs/tutorials/vscode-copilot-tutorial.md
+++ b/docs/tutorials/vscode-copilot-tutorial.md
@@ -1,0 +1,483 @@
+# Tutorial: VS Code Copilot — Full Feature Walkthrough
+
+> A hands-on guide that walks you through **every feature** Understudy
+> provides for VS Code Copilot, using the same TaskFlow project from the
+> CLI tutorial.
+
+## Prerequisites
+
+- VS Code with **GitHub Copilot** and **Copilot Chat** extensions installed.
+- Latest VS Code (for `applyTo` globs and prompt file support).
+- Understudy already deployed with the Copilot platform selected.
+
+If you followed the [Copilot CLI tutorial](copilot-cli-tutorial.md), your
+project already has all the files. If starting fresh:
+
+```bash
+mkdir taskflow && cd taskflow && git init
+understudy          # select Copilot platform
+code .              # open in VS Code
+```
+
+---
+
+## What's different from Copilot CLI?
+
+| Aspect | Copilot CLI | VS Code Copilot |
+|---|---|---|
+| Role activation | Manual (`/agent`, `/instructions`) | **Automatic** via `applyTo` globs |
+| Prompts | Not available | ✅ `.github/prompts/*.prompt.md` |
+| Context pinning | Tell the agent to read files | `#file:path` in chat |
+| Model selection | `/model` command | Picker in chat panel corner |
+| Guardrails | Always loaded | Always loaded (same) |
+| File editing | Agent writes files | Agent edits inline in editor |
+
+The key advantage: **you never need to manually switch agents**. VS Code
+applies the right role instructions based on which file you're editing.
+
+---
+
+## Part 1 — Understanding auto-applied instructions
+
+### 1.1 Feature: `applyTo` globs
+
+Open any `.github/instructions/*.instructions.md` file. Each has a YAML
+frontmatter like:
+
+```yaml
+---
+applyTo: "src/services/**,src/controllers/**,**/*.ts"
+---
+```
+
+This means: when you open or edit a file matching that glob, VS Code
+**automatically** loads that role's instructions into the Copilot context.
+
+### 1.2 Default `applyTo` mappings
+
+| Role | `applyTo` pattern | Activates when editing... |
+|---|---|---|
+| Architect | `docs/decisions.md,docs/spec.md,**/*.md` | Specs, ADRs, docs |
+| Backend | `src/services/**,src/controllers/**,**/*.ts` | Backend code |
+| Frontend | `src/components/**,**/*.tsx,**/*.css` | UI code |
+| DevOps | `**/Dockerfile,**/*.yml,infra/**,**/*.tf` | Infrastructure |
+| Security | `**/*.env*,**/auth/**,**/security/**` | Auth and secrets |
+| QA | `tests/**,**/*.test.*,**/*.spec.*` | Test files |
+| Guardrails | `**` | **Every file** (always active) |
+
+### 1.3 Try it: automatic role switching
+
+1. Open `docs/spec.md` → Architect instructions load.
+2. Open `src/services/auth.ts` → Backend instructions load.
+3. Open `tests/auth.test.ts` → QA instructions load.
+4. Open `Dockerfile` → DevOps instructions load.
+
+You can verify which instructions are loaded: open Copilot Chat and look at
+the **"Used references"** panel at the bottom of a response.
+
+---
+
+## Part 2 — Using prompt files
+
+### 2.1 Feature: Reusable prompts (`.github/prompts/`)
+
+VS Code Copilot supports prompt files — pre-written instructions you can
+invoke from the chat. Understudy deploys 5:
+
+| File | What it does |
+|---|---|
+| `start-session.prompt.md` | Reads spec, decisions, session-log and roster; gives status summary |
+| `end-session.prompt.md` | Updates session-log with today's work, decisions, next steps |
+| `design-feature.prompt.md` | Runs Architect's 8-step design process; writes ADR |
+| `security-review.prompt.md` | Focused security review of recent changes |
+| `understudy.prompt.md` | Explains what Understudy is, available roles, how to use them |
+
+### 2.2 How to invoke a prompt
+
+**Option A — Type in chat:**  
+Open Copilot Chat (`Ctrl+Alt+I` / `Cmd+Ctrl+I`) and type `/`. VS Code shows
+available prompts. Select one.
+
+**Option B — File explorer:**  
+Right-click a `.prompt.md` file → "Run with Copilot".
+
+**Option C — Command palette:**  
+`Ctrl+Shift+P` → "Copilot: Run Prompt File" → select from list.
+
+### 2.3 Exercise: Start a session
+
+Invoke the **start-session** prompt:
+
+```
+/start-session
+```
+
+Copilot reads `docs/spec.md`, `docs/decisions.md`, `docs/session-log.md`
+and `docs/team-roster.md`, then provides:
+
+- Current project state
+- Last session summary
+- Open items
+- Suggested next steps
+
+This replaces the manual "read these files" you would do in the CLI.
+
+---
+
+## Part 3 — Designing a feature
+
+### 3.1 Feature: `design-feature` prompt
+
+Invoke:
+
+```
+/design-feature
+```
+
+Copilot (acting as the Architect) will ask clarifying questions:
+
+```
+What feature would you like to design?
+```
+
+Answer:
+
+```
+Add a notification system: email users when a task is assigned to them
+or when a task's due date is approaching (24h before).
+```
+
+The Architect follows the 8-step process:
+1. Requirements clarification
+2. Constraint identification
+3. Alternative proposals (2-3)
+4. Trade-off evaluation
+5. Recommendation
+6. ADR documentation
+7. Mermaid diagram
+8. Security consultation
+
+The result is written to `docs/decisions.md` as ADR-0002.
+
+### 3.2 Feature: `#file:` — Pin context
+
+Want Copilot to consider a specific file while designing?
+
+```text
+Design the notification queue. Consider the existing auth flow in
+#file:src/services/auth.ts and the database schema in
+#file:src/db/schema.prisma.
+```
+
+The `#file:path` syntax tells Copilot to load that file into context.
+Useful when the auto-applied instructions aren't enough.
+
+---
+
+## Part 4 — Implementation with automatic role activation
+
+### 4.1 Backend work
+
+Open (or create) `src/services/notifications.ts`. Because this matches the
+Backend's `applyTo` pattern, Copilot automatically uses the Backend agent's
+expertise.
+
+In the Chat panel:
+
+```text
+Implement the notification service following ADR-0002.
+Requirements:
+- Queue notifications when tasks are assigned
+- Check for approaching due dates (cron job)
+- Send emails via SendGrid
+- Use environment variables for API keys
+```
+
+The Backend agent:
+- Writes code following the project's conventions
+- Uses parameterized queries
+- Reads environment variables (respecting guardrails)
+- Follows the error handling patterns from the existing codebase
+
+### 4.2 Test work
+
+Now open `tests/notifications.test.ts`. Because this matches the QA
+agent's `applyTo` pattern, Copilot switches to the QA perspective.
+
+```text
+Write tests for the notification service. Cover:
+- Task assignment triggers notification
+- Due date notification fires 24h before
+- Email service failure is handled gracefully
+- Duplicate notifications are prevented
+```
+
+The QA agent writes idiomatic Jest tests with proper mocking.
+
+### 4.3 Infrastructure work
+
+Open `docker-compose.yml`. DevOps instructions activate.
+
+```text
+Add a Redis service for the notification queue.
+Update the app service to connect to Redis.
+```
+
+DevOps adds the service following Docker best practices.
+
+---
+
+## Part 5 — Security review
+
+### 5.1 Feature: `security-review` prompt
+
+Before committing, run the security review:
+
+```
+/security-review
+```
+
+Copilot (as the Security agent) reviews your recent changes and checks:
+
+- API key handling (SendGrid key in env vars, not code)
+- Input validation on notification payloads
+- Rate limiting on email sends
+- SQL injection (parameterized queries)
+- PII in logs (no email addresses in plaintext logs)
+
+It produces a report with findings and recommendations.
+
+### 5.2 Feature: Guardrails — always active
+
+Try asking Copilot to do something dangerous while editing any file:
+
+```text
+Store the SendGrid API key directly in the source code so we don't
+need env vars in development.
+```
+
+Copilot refuses:
+
+> 🛡️ This violates the Security guardrail: "No secrets, no bypass". API
+> keys must come from environment variables. I'll use `process.env.SENDGRID_API_KEY`
+> and add the variable to `.env.example`.
+
+The guardrails are in `.github/instructions/guardrails.instructions.md`
+with `applyTo: "**"` — active on every single file.
+
+---
+
+## Part 6 — Model selection
+
+### 6.1 Feature: Model picker
+
+In the Copilot Chat panel, look at the **model selector** (usually in the
+top or bottom corner of the chat).
+
+Recommended models by task:
+
+| Task | Model | Why |
+|---|---|---|
+| Architecture design | Claude Opus / GPT-4o | Complex reasoning |
+| Code implementation | Claude Sonnet / GPT-4o-mini | Good speed/quality |
+| Quick fixes, formatting | Claude Haiku / GPT-4o-mini | Fast, cheap |
+| Security review | Claude Opus | Deeper analysis |
+
+### 6.2 When to switch
+
+- Before invoking `design-feature` → switch to Opus.
+- During implementation → Sonnet is fine.
+- For a quick rename or formatting → Haiku.
+
+These recommendations come from `understudy.yaml`:
+
+```yaml
+models:
+  architect: "claude-opus-4"
+  backend: "claude-sonnet-4"
+  frontend: "claude-sonnet-4"
+  devops: "claude-sonnet-4"
+  security: "claude-opus-4"
+  qa: "claude-sonnet-4"
+```
+
+---
+
+## Part 7 — Ending the session
+
+### 7.1 Feature: `end-session` prompt
+
+When you're done working:
+
+```
+/end-session
+```
+
+Copilot updates `docs/session-log.md` with:
+
+```markdown
+## Session — 2026-05-12
+
+### Completed
+- Designed notification system (ADR-0002)
+- Implemented notification service (src/services/notifications.ts)
+- Added Redis to docker-compose
+- Wrote tests (unit + integration)
+- Security review passed
+
+### Decisions
+- ADR-0002: Redis queue + SendGrid for notifications
+
+### Next steps
+- Implement email templates
+- Add notification preferences (opt-out)
+- E2E tests for notification flow
+
+### Blockers
+- None
+```
+
+### 7.2 Why this matters
+
+Tomorrow, when you (or a colleague) invoke `/start-session`, the AI
+reads this log and immediately picks up where you left off. No need to
+re-explain anything. This is Understudy's **persistent memory**.
+
+---
+
+## Part 8 — Caveman mode (optional)
+
+### 8.1 Enable caveman
+
+```bash
+understudy --caveman
+```
+
+This deploys:
+- `.github/instructions/caveman.instructions.md` (with `applyTo: "**"`)
+- `.github/prompts/compress.prompt.md`
+- `.github/prompts/restore.prompt.md`
+
+### 8.2 Feature: `/compress` prompt
+
+When a Copilot response is too verbose:
+
+```
+/compress
+```
+
+Copilot rewrites its last response in caveman style — dropping filler
+words, keeping code/paths/URLs intact. Saves 30-50% tokens.
+
+### 8.3 Feature: `/restore` prompt
+
+Need the full version back?
+
+```
+/restore
+```
+
+Copilot restores the last compressed response to full natural language.
+
+### 8.4 Automatic caveman
+
+With the role file deployed (`applyTo: "**"`), **all** Copilot responses
+automatically use the token-efficient style. No need to invoke `/compress`
+manually.
+
+---
+
+## Part 9 — Advanced tips
+
+### 9.1 Customizing `applyTo` for your project
+
+If your project uses a non-standard structure, edit the frontmatter:
+
+```yaml
+---
+applyTo: "packages/api/**,apps/server/**"
+---
+```
+
+Multiple patterns are comma-separated. `**` matches everything.
+
+### 9.2 Checking which instructions are active
+
+After any Copilot response, expand the **"Used references"** section at
+the bottom. It shows which instruction files were loaded.
+
+If the wrong role is active, check that your file matches the expected
+`applyTo` glob.
+
+### 9.3 Combining with Copilot CLI
+
+You can use both in the same project:
+- VS Code for interactive coding with auto-applied roles.
+- CLI for longer planning sessions, sub-agents and parallel work.
+
+Both read the same files (`AGENTS.md`, `.github/`, `docs/`), so session
+history is shared.
+
+### 9.4 Creating your own prompt files
+
+Add any `.prompt.md` file to `.github/prompts/`:
+
+```markdown
+---
+description: "Run database migration and verify schema"
+---
+Run the database migration with `npx prisma migrate dev`.
+Then verify the schema matches docs/spec.md section 3.
+Report any discrepancies.
+```
+
+It will appear in Copilot Chat's prompt list immediately.
+
+---
+
+## Quick reference card
+
+| Feature | How to use |
+|---|---|
+| Auto-applied roles | Open a file → matching role loads automatically |
+| Start session | `/start-session` prompt |
+| End session | `/end-session` prompt |
+| Design feature | `/design-feature` prompt |
+| Security review | `/security-review` prompt |
+| Pin file as context | `#file:path/to/file` in chat |
+| Change model | Model picker in chat panel |
+| Check active instructions | "Used references" panel |
+| Guardrails | Always active (`applyTo: "**"`) |
+| Caveman compress | `/compress` prompt |
+| Caveman restore | `/restore` prompt |
+| Add team member | `understudy --add-member` (terminal) |
+| Custom prompt | Add `.prompt.md` to `.github/prompts/` |
+
+---
+
+## Comparison: What you do differently vs CLI
+
+| Workflow step | In CLI | In VS Code |
+|---|---|---|
+| Start session | Manually ask to read docs | `/start-session` prompt |
+| Switch role | `/agent <name>` | Open a matching file (automatic) |
+| Load role details | `/instructions` | Automatic via `applyTo` |
+| Design | Tell the Architect | `/design-feature` prompt |
+| Security review | `/agent Security` + ask | `/security-review` prompt |
+| End session | Tell agent to update log | `/end-session` prompt |
+| Compress tokens | `/compact` | `/compress` prompt (caveman) |
+
+---
+
+## Next steps
+
+- Try the [Claude Code tutorial](claude-code-tutorial.md) — hooks, deny
+  lists, slash commands.
+- Read [Cross-Platform Workflows](../08-cross-platform-workflows.md) if
+  you use both VS Code and CLI.
+- Explore [Configuration Reference](../09-configuration.md) to tweak
+  model assignments and guardrails mode.
+
+---
+
+[← Copilot CLI tutorial](copilot-cli-tutorial.md) · [Back to tutorials index](README.md) · [Next: Claude Code →](claude-code-tutorial.md)


### PR DESCRIPTION
## Description

Add hands-on tutorials for all 4 supported platforms. Each tutorial walks through every Understudy feature available on that platform using the same example project (TaskFlow — Node.js REST API).

---

## Type of change

- [x] 📝 `docs` — documentation only

---

## What changes?

- New `docs/tutorials/copilot-cli-tutorial.md` — 12 parts: /agent, /instructions, /model, sub-agents, /compact, /diff, /context, guardrails, session flow, --add-member, --create-role, caveman
- New `docs/tutorials/vscode-copilot-tutorial.md` — 9 parts: applyTo auto-apply, prompt files, #file: context, model picker, guardrails, caveman compress/restore
- New `docs/tutorials/claude-code-tutorial.md` — 10 parts: 3 safety layers (CLAUDE.md + deny list + PreToolUse hook), per-agent model, slash commands, custom agents/commands, statusline
- New `docs/tutorials/cursor-tutorial.md` — 9 parts: 4 rule types (always/glob/agent-requested/manual), Agent panel, commands, custom rules, model in frontmatter, caveman
- New `docs/tutorials/README.md` — tutorials index
- Updated `docs/README.md` — added tutorials section to index

---

## How to test

```bash
# Verify all tutorial files exist
ls docs/tutorials/

# Check internal links
grep -r 'copilot-cli-tutorial\|vscode-copilot-tutorial\|claude-code-tutorial\|cursor-tutorial' docs/tutorials/ docs/README.md
```

---

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] `CHANGELOG.md` updated in the `[Unreleased]` section
- [x] `bash -n wizard.sh` passes without errors
- [x] ShellCheck passes locally (or new warnings are justified)
- [x] Affected documentation is updated