### PR TITLE
docs: rewrite all 4 tutorials as self-contained guides

### DIFF
--- a/docs/tutorials/claude-code-tutorial.md
+++ b/docs/tutorials/claude-code-tutorial.md
@@ -1,83 +1,174 @@
 # Tutorial: Claude Code — Full Feature Walkthrough
 
-> A hands-on guide that walks you through **every feature** Understudy
-> provides for Claude Code, using the same TaskFlow project from the
-> previous tutorials.
+> A complete, self-contained guide that walks you step by step through
+> **every feature** Understudy provides for Claude Code.
+> You do not need to read any other tutorial before this one.
 
-## Prerequisites
+---
 
-- Anthropic account with the `claude` CLI installed.
-- Understudy installed.
+## What you will learn
 
-If starting fresh:
+By the end of this tutorial you will have used:
+
+- `CLAUDE.md` — always-on global instructions
+- Agent files — per-role personas with automatic model assignment
+- `settings.json` deny list — block read/write to sensitive files
+- PreToolUse hook — block destructive commands before execution
+- Slash commands — `/project:start-session`, `/project:design-feature`…
+- Custom commands — create your own `/project:*` workflows
+- Custom agents — add new roles
+- Guardrails — 3 independent safety layers
+- Session protocol — persistent memory across sessions
+- `--add-member` / `--create-role` — extend the team
+- Caveman mode — compress/restore, hooks, statusline
+
+---
+
+## What you need before starting
+
+| Requirement | How to get it |
+|---|---|
+| An Anthropic account | [anthropic.com](https://www.anthropic.com) |
+| The `claude` CLI installed | Follow Anthropic's installation guide |
+| `bash` ≥ 4 | Comes with Linux/macOS. On Windows use Git Bash or WSL |
+| `git` | Any recent version |
+
+---
+
+## Step 1 — Install Understudy
+
+Open a terminal and run:
 
 ```bash
-mkdir taskflow && cd taskflow && git init
-understudy          # select "Claude Code" platform
-claude              # open the project
+curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash
+```
+
+This downloads the latest release, installs it to `~/.understudy/` and adds
+the `understudy` command to your PATH.
+
+Close and re-open your terminal (or `source ~/.bashrc`) so the command is
+available.
+
+Verify:
+
+```bash
+understudy --help
 ```
 
 ---
 
-## What makes Claude Code unique?
+## Step 2 — Create the example project
 
-Claude Code has the **richest enforcement layer** of all platforms:
+We will build **TaskFlow** — a simple task management REST API. The project
+is intentionally simple so you can focus on learning the AI workflow.
 
-| Exclusive feature | What it does |
-|---|---|
-| `settings.json` deny list | Claude refuses to read/write protected files |
-| PreToolUse hook | Blocks destructive commands before execution |
-| Per-agent model assignment | Each agent uses a different model automatically |
-| Slash commands | `/project:<name>` invokes pre-built workflows |
-| Statusline (caveman) | Shows real-time token compression savings |
+```bash
+mkdir taskflow
+cd taskflow
+git init
+```
 
 ---
 
-## Part 1 — Understanding the generated files
+## Step 3 — Deploy Understudy into the project
 
-After running `understudy`, your project has:
+Run the wizard:
 
-```
-CLAUDE.md                           ← Always loaded (project context + critical guardrails)
-.claude/
-├── agents/
-│   ├── architect.md                ← Each agent: name, description, model, tools
-│   ├── backend.md
-│   ├── frontend.md
-│   ├── devops.md
-│   ├── security.md
-│   ├── qa.md
-│   ├── git-specialist.md           ← Auto-deployed
-│   └── repo-documenter.md          ← Auto-deployed
-├── commands/
-│   ├── start-session.md            ← /project:start-session
-│   ├── end-session.md              ← /project:end-session
-│   ├── design-feature.md           ← /project:design-feature
-│   ├── security-review.md          ← /project:security-review
-│   └── understudy.md               ← /project:understudy
-├── hooks/
-│   └── guardrails-check.sh         ← PreToolUse hook
-└── settings.json                   ← Deny rules + hook wiring
-docs/
-├── spec.md
-├── decisions.md
-├── session-log.md
-└── team-roster.md
+```bash
+understudy
 ```
 
-### 1.1 Feature: `CLAUDE.md` — Always-on instructions
+The wizard asks 9 questions. Answer like this:
 
-Open `CLAUDE.md`. This file is loaded **every session, automatically**. It
-contains:
+| # | Question | What to enter |
+|---|---|---|
+| 1 | Project name | `taskflow` |
+| 2 | Short description | `Task management REST API` |
+| 3 | Project manager | Your name |
+| 4 | Tech stack | `Node.js + Express + PostgreSQL + Docker` |
+| 5 | Repository URL | `https://github.com/you/taskflow` (or leave blank) |
+| 6 | Guardrails mode | `split` (press Enter for default) |
+| 7 | Platforms | Select **Claude Code** |
+| 8 | Git: commit files? | `y` |
+| 9 | Git: local-only config? | `n` |
+
+> **Shortcut:** `understudy --here` auto-infers all values from your repo.
+
+---
+
+## Step 4 — Verify the generated files
+
+```bash
+find . -type f | sort
+```
+
+You should see:
+
+```
+./CLAUDE.md
+./.claude/agents/architect.md
+./.claude/agents/backend.md
+./.claude/agents/devops.md
+./.claude/agents/frontend.md
+./.claude/agents/git-specialist.md
+./.claude/agents/qa.md
+./.claude/agents/repo-documenter.md
+./.claude/agents/security.md
+./.claude/commands/design-feature.md
+./.claude/commands/end-session.md
+./.claude/commands/security-review.md
+./.claude/commands/start-session.md
+./.claude/commands/understudy.md
+./.claude/hooks/guardrails-check.sh
+./.claude/settings.json
+./docs/decisions.md
+./docs/session-log.md
+./docs/spec.md
+./docs/team-roster.md
+```
+
+### What each file does
+
+| File/folder | Purpose | Loaded automatically? |
+|---|---|---|
+| `CLAUDE.md` | Global instructions + critical guardrails. Claude reads it every session. | ✅ Yes, always |
+| `.claude/agents/<role>.md` | Agent definition: name, description, model, tools. | ❌ When you invoke the agent |
+| `.claude/commands/<name>.md` | Slash command templates. | ❌ When you run `/project:<name>` |
+| `.claude/settings.json` | Permission deny list + hook wiring. | ✅ Yes, always |
+| `.claude/hooks/guardrails-check.sh` | PreToolUse hook — blocks destructive commands. | ✅ Yes, before every tool call |
+| `docs/*.md` | Persistent memory (spec, decisions, session log). | ❌ Via commands or asking |
+
+---
+
+## Step 5 — Open the project with Claude
+
+```bash
+claude
+```
+
+Claude starts and automatically loads:
+- `CLAUDE.md` — project context, team rules, critical guardrails
+- `.claude/settings.json` — deny list and hook wiring
+
+You'll notice Claude already knows your project name, stack and rules.
+
+---
+
+## Step 6 — Feature: `CLAUDE.md` — Always-on instructions
+
+Open `CLAUDE.md` in an editor. It contains:
 
 - Project name, description, stack
 - Team rules (spec-first, documented decisions, traceable sessions)
 - Critical guardrails (security subset)
 - Reference to the full agent roster
 
-You never need to ask Claude to read it — it's always in context.
+This file is loaded **every session, automatically**. You never need to
+ask Claude to read it.
 
-### 1.2 Feature: Agent files with model assignment
+---
+
+## Step 7 — Feature: Agent files with per-agent model
 
 Open `.claude/agents/architect.md`:
 
@@ -90,13 +181,30 @@ tools: [read, edit, bash]
 ---
 ```
 
-The **model** field means: when you invoke the architect, Claude
-automatically uses Opus. The backend agent uses Sonnet. You never need to
-manually switch models.
+Key fields:
+- **`model`** — When you invoke this agent, Claude automatically switches
+  to Opus. The backend agent uses Sonnet. You never need to run `/model`.
+- **`tools`** — Which tools the agent can use.
 
-### 1.3 Feature: `settings.json` — Deny list
+This automatic model switching is **exclusive to Claude Code**. No other
+platform does this.
 
-Open `.claude/settings.json`. It contains entries like:
+### 7.1 Default model assignments
+
+| Agent | Model | Why |
+|---|---|---|
+| Architect | claude-opus-4 | Complex reasoning for system design |
+| Security | claude-opus-4 | Deep analysis for threat modeling |
+| Backend | claude-sonnet-4 | Good speed/quality for implementation |
+| Frontend | claude-sonnet-4 | Same |
+| DevOps | claude-sonnet-4 | Same |
+| QA | claude-sonnet-4 | Same |
+
+---
+
+## Step 8 — Feature: `settings.json` — Deny list
+
+Open `.claude/settings.json`. It contains:
 
 ```json
 {
@@ -110,155 +218,59 @@ Open `.claude/settings.json`. It contains entries like:
 }
 ```
 
-Claude will **refuse** to read or write any file matching these patterns.
-Even if you explicitly ask, it won't comply.
+This means Claude will **refuse** to read or write any file matching these
+patterns. Even if you explicitly ask, it won't comply.
 
----
+### 8.1 Exercise: Try to read a protected file
 
-## Part 2 — Starting a session
-
-### 2.1 Feature: `/project:start-session`
-
-```text
-You: /project:start-session
 ```
-
-Claude reads `docs/spec.md`, `docs/decisions.md`, `docs/session-log.md`
-and `docs/team-roster.md`, then provides:
-
-- Current project status
-- Last session summary
-- Open items
-- Suggested next steps
-
-Since the project is new, it reports empty docs and suggests writing a spec.
-
-### 2.2 Feature: `/project:understudy` — Discover capabilities
-
-Not sure what's available? Ask:
-
-```text
-You: /project:understudy
-```
-
-Claude explains all available agents, commands, guardrails and the
-recommended workflow. Useful for onboarding new team members.
-
----
-
-## Part 3 — Designing with agents
-
-### 3.1 Feature: Invoke agent by name
-
-```text
-You: Use the architect agent to design a REST API for task management.
-     Features: user auth (JWT), CRUD tasks, assignment, filtering.
-     Write the spec in docs/spec.md.
-```
-
-Claude switches to the architect persona (Opus model) and:
-1. Asks clarifying questions
-2. Writes a formal spec in `docs/spec.md`
-
-### 3.2 Feature: `/project:design-feature`
-
-For a more structured approach:
-
-```text
-You: /project:design-feature
-```
-
-Claude (as Architect) follows the 8-step design process:
-1. Requirements clarification
-2. Constraint identification
-3. 2-3 alternatives with trade-offs
-4. Recommendation with justification
-5. ADR in `docs/decisions.md`
-6. Mermaid architecture diagram
-7. Security consultation
-8. Implementation plan
-
-```text
-Claude: What feature would you like to design?
-You: A notification system — email users when tasks are assigned or
-     due dates approach (24h before).
-```
-
-Result: ADR-0002 in `docs/decisions.md` with full rationale.
-
-### 3.3 Feature: Per-agent model switching
-
-Notice you didn't run `/model` at any point. The architect's frontmatter
-says `model: claude-opus-4`, so Claude uses Opus automatically for design.
-When you invoke the backend agent later, it switches to Sonnet.
-
-This is **exclusive to Claude Code** — no other platform supports this.
-
----
-
-## Part 4 — Security: three layers of protection
-
-### 4.1 Layer 1: Instructions (CLAUDE.md)
-
-Critical guardrails are embedded directly in `CLAUDE.md`. They are always
-in context, always respected:
-
-- No secrets in code
-- No destructive operations without confirmation
-- Spec-first development
-- Parameterized queries only
-
-### 4.2 Layer 2: Deny list (settings.json)
-
-Try to read a secret file:
-
-```text
-You: Show me the contents of .env
+Show me the contents of .env
 ```
 
 Claude refuses:
 
-> I cannot read `.env` — it's in the deny list in `.claude/settings.json`.
-> This file likely contains secrets. If you need to reference environment
-> variables, check `.env.example` instead.
+> I cannot read `.env` — it's in the deny list. If you need to reference
+> environment variables, check `.env.example` instead.
 
-**Try writing to a protected path:**
+### 8.2 Exercise: Try to write to a protected path
 
-```text
-You: Create a file called secrets/api-keys.json with our API keys.
+```
+Create a file called secrets/api-keys.json with our API keys.
 ```
 
-Claude refuses again — the deny list blocks both reads and writes.
+Claude refuses — the deny list blocks both reads and writes.
 
-### 4.3 Layer 3: PreToolUse hook (guardrails-check.sh)
+---
+
+## Step 9 — Feature: PreToolUse hook — Block destructive commands
 
 This is Claude Code's most powerful safety feature. Before **every tool
-call**, the hook runs and checks the command against destructive patterns.
+call**, the guardrails hook runs and checks the command against destructive
+patterns.
 
-**The hook blocks commands like:**
+### 9.1 What gets blocked
 
 | Blocked pattern | Example |
 |---|---|
-| `rm -rf` | `rm -rf /` or `rm -rf node_modules` (with flag) |
+| `rm -rf` | `rm -rf /` or `rm -rf node_modules` |
 | `DROP TABLE` / `DROP DATABASE` | SQL destructive operations |
 | `terraform destroy` | Infrastructure destruction |
 | `kubectl delete namespace` | Kubernetes resource deletion |
 | `git push --force` | Force-pushing to remote |
 | `docker system prune` | Bulk container/image removal |
 
-**Exercise — Trigger the hook:**
+### 9.2 Exercise: Trigger the hook
 
-```text
-You: Run: rm -rf src/
+```
+Run: rm -rf src/
 ```
 
 The hook intercepts and blocks:
 
 > ⚠️ BLOCKED by guardrails hook: destructive command detected (`rm -rf`).
-> This requires explicit PM confirmation. Please confirm you want to
-> delete the entire src/ directory, or suggest an alternative.
+> This requires explicit PM confirmation.
 
-### 4.4 How the hook works internally
+### 9.3 How the hook works internally
 
 Open `.claude/hooks/guardrails-check.sh`:
 
@@ -276,7 +288,6 @@ DESTRUCTIVE_PATTERNS=(
   "git push --force"
   "git push -f"
   "docker system prune"
-  # ... more patterns
 )
 ```
 
@@ -286,9 +297,9 @@ The hook:
 3. If matched → exits with code 1 (blocks execution)
 4. If clean → exits with code 0 (allows execution)
 
-### 4.5 Customizing the hook
+### 9.4 Customize the hook
 
-Add your own patterns:
+Add your own patterns by editing the script:
 
 ```bash
 DESTRUCTIVE_PATTERNS=(
@@ -301,66 +312,228 @@ DESTRUCTIVE_PATTERNS=(
 
 ---
 
-## Part 5 — Implementation
+## Step 10 — Three independent safety layers
 
-### 5.1 Invoke the backend agent
+Claude Code enforces guardrails through 3 independent layers. If one fails
+to catch something, the next one does:
 
-```text
-You: Use the backend agent to implement the task API following ADR-0001.
-     Set up:
-     - Express project structure
-     - Database schema with Prisma
-     - Auth endpoints (register, login, refresh)
-     - Task CRUD endpoints
-     - Input validation with Zod
-     - Error handling middleware
-     - Dockerfile + docker-compose.yml
-```
+| Layer | Mechanism | What it catches |
+|---|---|---|
+| 1. Instructions | `CLAUDE.md` (always loaded) | Secrets, scope, spec-first, PII |
+| 2. Deny list | `settings.json` | File access to `.env`, secrets, keys |
+| 3. Hook | `guardrails-check.sh` (PreToolUse) | Destructive shell commands |
 
-Claude switches to the backend persona (Sonnet model) and implements
-everything. Because `CLAUDE.md` is always loaded, it follows the team
-rules automatically.
-
-### 5.2 Combine agents in a single session
-
-Unlike Copilot CLI, you don't need to restart or use `/agent`. Just tell
-Claude which agent to use:
-
-```text
-You: Now use the devops agent to add a GitHub Actions workflow with:
-     - Lint, unit tests, integration tests (PostgreSQL service)
-     - Build and push Docker image to GHCR
-     - Deploy to staging on PR merge
-```
-
-Claude switches persona seamlessly. The context (all files it created
-earlier) remains available.
+No other platform has all three layers.
 
 ---
 
-## Part 6 — Slash commands
+## Step 11 — Feature: Slash commands
 
-### 6.1 Feature: `/project:security-review`
+### 11.1 Available commands
 
-Before committing:
+| Command | What it does |
+|---|---|
+| `/project:start-session` | Reads docs/*.md and summarizes project state |
+| `/project:end-session` | Updates session-log with today's work |
+| `/project:design-feature` | Architect's 8-step design process + ADR |
+| `/project:security-review` | Security review of recent changes |
+| `/project:understudy` | Explains capabilities, roles, workflow |
 
-```text
-You: /project:security-review
+Plus Claude's native commands: `/model`, `/compact`, `/agents`, etc.
+
+### 11.2 Start a session
+
+```
+/project:start-session
 ```
 
-Claude (as Security, model: Opus) reviews all recent changes:
+Claude reads `docs/spec.md`, `docs/decisions.md`, `docs/session-log.md`
+and `docs/team-roster.md`, then provides:
 
-- JWT implementation review
-- Input validation completeness
-- SQL injection surface (parameterized queries check)
-- Secrets in code (none, good)
-- Authorization logic (can user X access user Y's tasks?)
-- Rate limiting recommendations
+- Current project status
+- Last session summary
+- Open items
+- Suggested next steps
 
-### 6.2 Feature: `/project:end-session`
+Since this is a new project, it reports empty docs and suggests writing a
+spec first.
 
-```text
-You: /project:end-session
+### 11.3 Discover capabilities
+
+```
+/project:understudy
+```
+
+Claude explains all available agents, commands, guardrails and the
+recommended workflow. Useful for onboarding.
+
+---
+
+## Step 12 — Design a feature
+
+### 12.1 Invoke the Architect agent
+
+```
+Use the architect agent to design a REST API for task management.
+Features: user auth (JWT), CRUD tasks, assignment, filtering.
+Write the spec in docs/spec.md.
+```
+
+Claude switches to the architect persona (Opus model automatically) and:
+1. Asks clarifying questions
+2. Writes a formal spec in `docs/spec.md`
+
+### 12.2 Use the design command
+
+```
+/project:design-feature
+```
+
+Claude (as Architect) follows the 8-step process:
+1. Requirements clarification
+2. Constraint identification
+3. 2-3 alternatives with trade-offs
+4. Recommendation with justification
+5. ADR in `docs/decisions.md`
+6. Mermaid architecture diagram
+7. Security consultation
+8. Implementation plan
+
+---
+
+## Step 13 — Security review of the design
+
+```
+Use the security agent to review ADR-0001 in docs/decisions.md.
+Produce a threat model covering JWT auth, input validation,
+SQL injection, authorization, and secrets management.
+Add security requirements to docs/spec.md.
+```
+
+Claude switches to the Security agent (Opus model automatically) and adds
+constraints like:
+- JWT expiry ≤ 1h, refresh tokens httpOnly
+- Parameterized queries only
+- Rate limiting on auth endpoints
+- Input validation with schema library
+
+---
+
+## Step 14 — Implement with the Backend agent
+
+```
+Use the backend agent to implement the TaskFlow API following ADR-0001.
+Set up:
+- Express project structure
+- Database schema with Prisma
+- Auth endpoints (register, login, refresh)
+- Task CRUD endpoints
+- Input validation with Zod
+- Error handling middleware
+- Dockerfile + docker-compose.yml
+- .env.example (no real secrets)
+```
+
+Claude switches to the Backend agent (Sonnet model automatically) and
+implements everything. `CLAUDE.md` is always loaded, so team rules are
+followed automatically.
+
+### 14.1 Combine agents in one session
+
+You can switch agents without restarting. Just tell Claude which to use:
+
+```
+Now use the devops agent to add a GitHub Actions workflow with:
+- Lint, unit tests, integration tests (PostgreSQL service)
+- Build and push Docker image to GHCR
+```
+
+Claude switches persona seamlessly. All files from earlier remain in context.
+
+---
+
+## Step 15 — QA: Write tests
+
+```
+Use the qa agent to write tests:
+1. Unit tests for auth service (register, login, token validation)
+2. Unit tests for task CRUD
+3. Integration tests (supertest)
+4. Edge cases: expired tokens, invalid input, unauthorized access
+Use Jest. Create a test plan first, then implement.
+```
+
+---
+
+## Step 16 — Security review before committing
+
+```
+/project:security-review
+```
+
+Claude (as Security, Opus model) reviews all recent changes for:
+- Hardcoded secrets
+- SQL injection
+- Missing input validation
+- Broken authentication/authorization
+- PII exposure
+- Missing rate limiting
+
+---
+
+## Step 17 — Guardrails demonstrations
+
+### 17.1 Security guardrail
+
+```
+Add the database connection string directly to config.ts:
+postgresql://admin:<PASSWORD>@prod-db.example.com/taskflow
+```
+
+Claude refuses:
+
+> 🛡️ Guardrail: Security — No secrets in code. I'll use
+> `process.env.DATABASE_URL` and add it to `.env.example`.
+
+### 17.2 Process guardrail
+
+```
+Add a WebSocket real-time feature. Just code it, skip the design.
+```
+
+Claude pushes back:
+
+> 🛡️ Guardrail: Process — Spec-first. I should update docs/spec.md,
+> create an ADR, get Security review, then implement.
+
+### 17.3 Destructive guardrail
+
+```
+Drop the users table and recreate it from scratch.
+```
+
+The PreToolUse hook blocks the `DROP TABLE` command:
+
+> ⚠️ BLOCKED: Destructive operation. Alternative: create a migration
+> that renames the table, creates the new schema, migrates data.
+
+### 17.4 Scope guardrail
+
+```
+Use the frontend agent to modify the database schema.
+```
+
+Claude (as Frontend) defers:
+
+> 🛡️ Scope: Database schema is Backend's responsibility. I can describe
+> what schema changes the frontend needs, then Backend implements them.
+
+---
+
+## Step 18 — End the session
+
+```
+/project:end-session
 ```
 
 Claude updates `docs/session-log.md`:
@@ -373,14 +546,14 @@ Claude updates `docs/session-log.md`:
 - Designed architecture (ADR-0001)
 - Implemented auth + task CRUD
 - Docker setup
-- CI/CD pipeline
+- Tests (unit + integration)
 - Security review passed
 
 ### Decisions
 - ADR-0001: Express + Prisma (type safety, DX)
 
 ### Next steps
-- Notification system (ADR-0002)
+- Notification system
 - E2E tests
 - Production deployment
 
@@ -388,9 +561,16 @@ Claude updates `docs/session-log.md`:
 - None
 ```
 
-### 6.3 Feature: Creating custom commands
+Next time you run `/project:start-session`, Claude reads this and picks up
+where you left off.
 
-Add any file to `.claude/commands/`:
+---
+
+## Step 19 — Feature: Create custom commands
+
+Add any file to `.claude/commands/`. It's immediately invocable.
+
+Example — `.claude/commands/weekly-report.md`:
 
 ```markdown
 ---
@@ -402,186 +582,31 @@ Read docs/session-log.md for the last 7 days and produce a
 stakeholder-level report: achievements, risks, blockers, next steps.
 ```
 
-Invoke it immediately:
+Invoke it:
 
-```text
-You: /project:weekly-report
+```
+/project:weekly-report
 ```
 
-More ideas for custom commands:
+More ideas:
 
-| Command | Purpose |
+| Command file | Purpose |
 |---|---|
-| `db-migrate` | Generate and run Prisma migrations |
-| `code-review` | Review staged changes against coding standards |
-| `update-docs` | Sync README and API docs with current code |
-| `dependency-check` | Audit npm packages for vulnerabilities |
+| `db-migrate.md` | Generate and run Prisma migrations |
+| `code-review.md` | Review staged changes against standards |
+| `update-docs.md` | Sync README and API docs with code |
+| `dependency-check.md` | Audit npm packages for vulnerabilities |
 
 ---
 
-## Part 7 — Guardrails demonstrations
-
-### 7.1 Security guardrail: No secrets
-
-```text
-You: Add the database connection string directly to config.ts:
-     postgresql://admin:<PASSWORD>@prod-db.example.com/taskflow
-```
-
-Claude refuses:
-
-> 🛡️ Guardrail: Security — No secrets in code. I'll use
-> `process.env.DATABASE_URL` and add the variable to `.env.example`
-> (without real values).
-
-### 7.2 Process guardrail: Spec-first
-
-```text
-You: Add a real-time chat feature to the app. Just implement it, no design.
-```
-
-Claude pushes back:
-
-> 🛡️ Guardrail: Process — Spec-first. A real-time chat feature is a
-> significant addition. I need to:
-> 1. Update docs/spec.md with the requirement
-> 2. Design it (ADR) with trade-offs (WebSocket vs SSE vs polling)
-> 3. Get Security review (new attack surface)
-> 4. Then implement
->
-> Would you like me to start with the design?
-
-### 7.3 Destructive guardrail: Confirmation required
-
-```text
-You: Drop the users table and recreate it from scratch.
-```
-
-The PreToolUse hook blocks the `DROP TABLE` command:
-
-> ⚠️ BLOCKED: Destructive operation (`DROP TABLE`). This requires PM
-> confirmation. Alternative: I can create a migration that renames the
-> table, creates the new schema, migrates data, then drops the old one.
-
-### 7.4 Scope guardrail: Role boundaries
-
-```text
-You: Use the frontend agent to modify the database schema.
-```
-
-Claude (as Frontend) acknowledges it's not its domain:
-
-> 🛡️ Scope: Database schema is the Backend agent's responsibility.
-> I can describe what schema changes the frontend needs (e.g., a
-> `preferences` column for UI settings), and the backend agent can
-> implement them.
-
----
-
-## Part 8 — Caveman mode (optional)
-
-### 8.1 Enable caveman
-
-```bash
-understudy --caveman
-```
-
-This deploys:
-- `.claude/agents/caveman.md` — the caveman role agent
-- `.claude/commands/compress.md` — `/project:compress`
-- `.claude/commands/restore.md` — `/project:restore`
-- Hooks: `SessionStart` + `UserPromptSubmit` (reinforcement)
-- Statusline script showing compression savings
-
-### 8.2 Feature: `/project:compress`
-
-Compress a verbose Markdown file:
-
-```text
-You: /project:compress docs/decisions.md
-```
-
-The compressor:
-1. Backs up `docs/decisions.md` → `docs/decisions.original.md`
-2. Rewrites the file in caveman style (drops filler, keeps code/paths)
-3. Reports token savings (typically 30-50%)
-
-### 8.3 Feature: `/project:restore`
-
-Restore the original:
-
-```text
-You: /project:restore docs/decisions.md
-```
-
-Restores from the `.original.md` backup.
-
-### 8.4 Feature: Statusline (Claude Code exclusive)
-
-With caveman enabled, Claude's statusline shows real-time stats:
-
-```
-🐉 caveman | saved: 847 tokens (38%) | session: 12.4k tokens
-```
-
-This is exclusive to Claude Code — no other platform has a statusline.
-
-### 8.5 Feature: Reinforcement hooks
-
-The `SessionStart` hook reminds Claude to use caveman style at the
-beginning of every session. The `UserPromptSubmit` hook reinforces it on
-every message. This means caveman stays active without you needing to
-remind it.
-
----
-
-## Part 9 — Advanced patterns
-
-### 9.1 Multi-agent workflow in one session
-
-```text
-You: Let's build the notification feature end-to-end.
-
-     1. Use the architect agent to design it (ADR-0002 already exists,
-        just verify it's still valid)
-     2. Use the security agent to review the design for risks
-     3. Use the backend agent to implement the queue + email service
-     4. Use the qa agent to write tests
-     5. Use the devops agent to add Redis to docker-compose and CI
-```
-
-Claude executes each step in sequence, switching models as appropriate:
-- Architect (Opus) → Security (Opus) → Backend (Sonnet) → QA (Sonnet) → DevOps (Sonnet)
-
-### 9.2 Extending the deny list
-
-Need to protect more files?
-
-Edit `.claude/settings.json`:
-
-```json
-{
-  "deny": [
-    ".env",
-    ".env.*",
-    "secrets/**",
-    "**/*.key",
-    "**/*.pem",
-    "terraform.tfstate",
-    "*.tfvars",
-    "credentials.json"
-  ]
-}
-```
-
-### 9.3 Adding new agents
+## Step 20 — Feature: Create custom agents
 
 Create `.claude/agents/dba.md`:
 
 ```yaml
 ---
 name: dba
-description: "Database Administrator — schema design, migrations, performance"
+description: "Database Administrator — schema, migrations, performance"
 model: claude-sonnet-4
 tools: [read, edit, bash]
 ---
@@ -600,35 +625,127 @@ You are the Database Administrator of the Understudy team.
 ## How you work
 1. Read docs/spec.md for data requirements
 2. Design schemas with proper normalization
-3. Write migrations that are reversible
+3. Write reversible migrations
 4. Add appropriate indexes
 5. Document decisions in docs/decisions.md
 ```
 
 Invoke immediately:
 
-```text
-You: Use the dba agent to optimize the tasks query with proper indexing.
+```
+Use the dba agent to optimize the tasks query with proper indexing.
 ```
 
 ---
 
-## Part 10 — Claude Code vs other platforms
+## Step 21 — Extend the deny list
 
-| Feature | Claude Code | Copilot CLI | VS Code | Cursor |
-|---|---|---|---|---|
-| Auto-loaded instructions | ✅ CLAUDE.md | ✅ copilot-instructions.md | ✅ Same | ✅ Rules |
-| Per-agent model | ✅ Automatic | ❌ Manual `/model` | ❌ Manual | ✅ Frontmatter |
-| Deny list (file protection) | ✅ settings.json | ❌ | ❌ | ❌ |
-| PreToolUse hook | ✅ guardrails-check.sh | ❌ | ❌ | ❌ |
-| Slash commands | ✅ `/project:name` | ❌ | ✅ Prompt files | ✅ Commands |
-| Sub-agents (parallel) | ❌ | ✅ | ❌ | ❌ |
-| Auto-apply by file type | ❌ | ❌ | ✅ `applyTo` | ✅ `globs` |
-| Caveman statusline | ✅ | ❌ | ❌ | ❌ |
+Edit `.claude/settings.json`:
+
+```json
+{
+  "deny": [
+    ".env",
+    ".env.*",
+    "secrets/**",
+    "**/*.key",
+    "**/*.pem",
+    "terraform.tfstate",
+    "*.tfvars",
+    "credentials.json"
+  ]
+}
+```
 
 ---
 
-## Quick reference card
+## Step 22 — Feature: `--add-member` — Extend the team
+
+```bash
+# Exit Claude (Ctrl+C), then:
+understudy --add-member
+```
+
+Select from the catalog (data-engineer, ml-engineer, sre, tech-writer…).
+The role is deployed to `.claude/agents/` automatically.
+
+---
+
+## Step 23 — Feature: `--create-role` — Create a custom role
+
+```bash
+understudy --create-role
+```
+
+The wizard asks for: name, title, description, expertise, motto.
+Saved in `roles/` for all future projects.
+
+---
+
+## Step 24 — Caveman mode (optional)
+
+### 24.1 Enable it
+
+```bash
+understudy --caveman
+```
+
+This deploys:
+- `.claude/agents/caveman.md` — caveman role agent
+- `.claude/commands/compress.md` — `/project:compress`
+- `.claude/commands/restore.md` — `/project:restore`
+- Hooks: `SessionStart` + `UserPromptSubmit` (reinforcement)
+- Statusline script showing compression savings
+
+### 24.2 Feature: `/project:compress`
+
+```
+/project:compress docs/decisions.md
+```
+
+The compressor:
+1. Backs up `docs/decisions.md` → `docs/decisions.original.md`
+2. Rewrites in caveman style (drops filler, keeps code/paths)
+3. Reports token savings (typically 30-50%)
+
+### 24.3 Feature: `/project:restore`
+
+```
+/project:restore docs/decisions.md
+```
+
+Restores from the `.original.md` backup.
+
+### 24.4 Feature: Statusline (Claude Code exclusive)
+
+With caveman enabled, Claude's statusline shows real-time stats:
+
+```
+🐉 caveman | saved: 847 tokens (38%) | session: 12.4k tokens
+```
+
+No other platform has a statusline.
+
+### 24.5 Feature: Reinforcement hooks
+
+The `SessionStart` hook reminds Claude to use caveman style at the start
+of every session. The `UserPromptSubmit` hook reinforces on every message.
+Caveman stays active without reminders.
+
+### 24.6 See the difference
+
+**Normal:**
+> I'll create a new Express middleware function that validates the JWT
+> token from the Authorization header and attaches the decoded user
+> payload to the request object for use in downstream handlers.
+
+**Caveman:**
+> Creating JWT middleware → validates `Authorization` header, attaches
+> decoded user to `req.user`.
+
+---
+
+## Complete reference
 
 | Feature | How to use |
 |---|---|
@@ -637,28 +754,45 @@ You: Use the dba agent to optimize the tasks query with proper indexing.
 | Design feature | `/project:design-feature` |
 | Security review | `/project:security-review` |
 | Discover capabilities | `/project:understudy` |
-| Invoke agent | "Use the `<name>` agent to..." |
-| List agents | `/agents` (native Claude command) |
+| Invoke agent | "Use the `<name>` agent to…" |
+| List agents | `/agents` (native command) |
 | Change model | `/model` (or let per-agent model handle it) |
 | Compress tokens | `/compact` (native) |
 | Protected files | Edit `.claude/settings.json` deny list |
-| Custom command | Add `.md` file to `.claude/commands/` |
-| Custom agent | Add `.md` file to `.claude/agents/` |
-| Extend guardrails hook | Edit `.claude/hooks/guardrails-check.sh` |
+| Custom command | Add `.md` to `.claude/commands/` |
+| Custom agent | Add `.md` to `.claude/agents/` |
+| Extend hook | Edit `.claude/hooks/guardrails-check.sh` |
 | Caveman compress | `/project:compress` |
 | Caveman restore | `/project:restore` |
+| Add team member | `understudy --add-member` (terminal) |
+| Create new role | `understudy --create-role` (terminal) |
 
 ---
 
-## Next steps
+## Tips
 
-- Try the [Cursor tutorial](cursor-tutorial.md) — rules, agents, MDC
-  format, glob-based auto-attach.
-- Read [Cross-Platform Workflows](../08-cross-platform-workflows.md) to
-  combine Claude Code with other tools in the same project.
-- See [Configuration Reference](../09-configuration.md) for model and
-  guardrails customization.
+- Claude Code has **3 safety layers** (instructions + deny list + hook).
+  No other platform has all three.
+- Per-agent model switching is automatic. You don't need `/model`.
+- Keep the deny list strict — even `cat` can't read denied files.
+- Use the session-log protocol. Claude's deep reasoning shines when
+  context is accurate.
+- If a hook blocks something you genuinely need, confirm explicitly in
+  chat — don't disable the hook.
 
 ---
 
-[← VS Code tutorial](vscode-copilot-tutorial.md) · [Back to tutorials index](README.md) · [Next: Cursor →](cursor-tutorial.md)
+## Troubleshooting
+
+| Problem | Solution |
+|---|---|
+| Claude doesn't know the project | Verify `CLAUDE.md` exists at project root |
+| Agent not found | Check `.claude/agents/` for the agent file |
+| Deny list not working | Verify `.claude/settings.json` is valid JSON |
+| Hook blocks a legitimate command | Confirm explicitly; or edit the hook patterns |
+| `/project:*` command not found | Check file exists in `.claude/commands/` |
+| `understudy` command not found | Re-open terminal or `source ~/.bashrc` |
+
+---
+
+[Back to tutorials index](README.md)

--- a/docs/tutorials/copilot-cli-tutorial.md
+++ b/docs/tutorials/copilot-cli-tutorial.md
@@ -1,116 +1,178 @@
 # Tutorial: GitHub Copilot CLI — Full Feature Walkthrough
 
-> A hands-on guide that walks you through **every feature** Understudy
-> provides for Copilot CLI, using a real-world example project.
-
-## The example project: TaskFlow API
-
-Throughout this tutorial you will build **TaskFlow** — a task management REST
-API with user authentication. This is intentionally simple so you can focus
-on learning the AI workflow, not the domain.
-
-**Stack:** Node.js + Express + PostgreSQL  
-**Goal:** A CRUD API for tasks with user auth, deployed with Docker.
+> A complete, self-contained guide that walks you step by step through
+> **every feature** Understudy provides for GitHub Copilot CLI.
+> You do not need to read any other tutorial before this one.
 
 ---
 
-## Part 1 — Setup and deployment
+## What you will learn
 
-### 1.1 Create the project folder
+By the end of this tutorial you will have used:
+
+- `/agent` — switch between AI personas (Architect, Backend, Security…)
+- `/instructions` — load detailed role instructions into context
+- `/model` — pick the best model for the task
+- `/compact` — compress the conversation to save tokens
+- `/diff` — review pending file changes
+- `/context` — see token usage and loaded files
+- Sub-agents — split work across parallel agents
+- Guardrails — see how the AI refuses unsafe operations
+- Session protocol — persistent memory across sessions
+- `--add-member` / `--create-role` — extend the team
+- Caveman mode — token-efficient responses
+
+---
+
+## What you need before starting
+
+| Requirement | How to get it |
+|---|---|
+| A GitHub Copilot subscription | [github.com/features/copilot](https://github.com/features/copilot) |
+| The `copilot` CLI | `gh extension install github/gh-copilot` or standalone binary |
+| `bash` ≥ 4 | Comes with Linux/macOS. On Windows use Git Bash or WSL |
+| `git` | Any recent version |
+
+---
+
+## Step 1 — Install Understudy
+
+Open a terminal and run:
 
 ```bash
-mkdir taskflow && cd taskflow
+curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash
+```
+
+This downloads the latest release, installs it to `~/.understudy/` and adds
+the `understudy` command to your PATH.
+
+Close and re-open your terminal (or `source ~/.bashrc`) so the command is
+available.
+
+Verify:
+
+```bash
+understudy --help
+```
+
+You should see the usage information.
+
+---
+
+## Step 2 — Create the example project
+
+We will build **TaskFlow** — a simple task management REST API. The project
+is intentionally simple so you can focus on learning the AI workflow.
+
+```bash
+mkdir taskflow
+cd taskflow
 git init
 ```
 
-### 1.2 Deploy Understudy
+---
+
+## Step 3 — Deploy Understudy into the project
+
+Run the wizard:
 
 ```bash
 understudy
 ```
 
-The wizard asks 9 questions. Answer like this for the tutorial:
+The wizard asks 9 questions. Answer like this:
 
-| # | Question | Answer |
+| # | Question | What to enter |
 |---|---|---|
 | 1 | Project name | `taskflow` |
 | 2 | Short description | `Task management REST API` |
 | 3 | Project manager | Your name |
 | 4 | Tech stack | `Node.js + Express + PostgreSQL + Docker` |
-| 5 | Repository URL | `https://github.com/you/taskflow` |
-| 6 | Guardrails mode | `split` (recommended) |
-| 7 | Platforms | `Copilot` |
+| 5 | Repository URL | `https://github.com/you/taskflow` (or leave blank) |
+| 6 | Guardrails mode | `split` (press Enter for default) |
+| 7 | Platforms | Select **Copilot** only |
 | 8 | Git: commit files? | `y` |
 | 9 | Git: local-only config? | `n` |
 
-> **Shortcut:** If you already have a repo with a `package.json` and a
-> remote configured, use `understudy --here` to auto-infer all values.
-
-### 1.3 Verify the generated files
-
-```bash
-ls -la
-```
-
-You should see:
-
-```
-AGENTS.md                                 ← Team definition
-.github/copilot-instructions.md           ← Global instructions (always active)
-.github/instructions/
-    architect.instructions.md
-    backend.instructions.md
-    frontend.instructions.md
-    devops.instructions.md
-    security.instructions.md
-    qa-engineer.instructions.md
-    guardrails.instructions.md            ← Full guardrails (always active)
-    git-specialist.instructions.md        ← Auto-deployed
-    repo-documenter.instructions.md       ← Auto-deployed
-.github/prompts/
-    start-session.prompt.md
-    end-session.prompt.md
-    design-feature.prompt.md
-    security-review.prompt.md
-    understudy.prompt.md
-docs/
-    spec.md
-    decisions.md
-    session-log.md
-    team-roster.md
-```
-
-> **What each file does:**
->
-> - `AGENTS.md` — Copilot reads this automatically. It defines the agents
->   you can select with `/agent`.
-> - `.github/copilot-instructions.md` — Loaded automatically in every
->   conversation. Contains project context + critical guardrails.
-> - `.github/instructions/*.instructions.md` — Detailed per-role
->   instructions. Toggled with `/instructions`.
-> - `docs/*.md` — Persistent memory. The AI reads/writes these to maintain
->   context across sessions.
+> **Shortcut:** If you already have a repo with a `package.json` and a git
+> remote, you can use `understudy --here` to auto-infer all values instead
+> of answering questions.
 
 ---
 
-## Part 2 — Starting your first session
+## Step 4 — Verify the generated files
 
-### 2.1 Open Copilot CLI
+```bash
+find . -type f | sort
+```
+
+You should see these files:
+
+```
+./AGENTS.md
+./.github/copilot-instructions.md
+./.github/instructions/architect.instructions.md
+./.github/instructions/backend.instructions.md
+./.github/instructions/devops.instructions.md
+./.github/instructions/frontend.instructions.md
+./.github/instructions/git-specialist.instructions.md
+./.github/instructions/guardrails.instructions.md
+./.github/instructions/qa-engineer.instructions.md
+./.github/instructions/repo-documenter.instructions.md
+./.github/instructions/security.instructions.md
+./.github/prompts/design-feature.prompt.md
+./.github/prompts/end-session.prompt.md
+./.github/prompts/security-review.prompt.md
+./.github/prompts/start-session.prompt.md
+./.github/prompts/understudy.prompt.md
+./docs/decisions.md
+./docs/session-log.md
+./docs/spec.md
+./docs/team-roster.md
+```
+
+### What each file does
+
+| File/folder | Purpose | Loaded automatically? |
+|---|---|---|
+| `AGENTS.md` | Defines the team — names, roles, rules. Copilot reads it to know which agents exist. | ✅ Yes |
+| `.github/copilot-instructions.md` | Global project instructions + critical guardrails. Always in context. | ✅ Yes |
+| `.github/instructions/<role>.instructions.md` | Detailed instructions for each role (personality, expertise, standards). | ❌ On demand (`/instructions`) |
+| `.github/instructions/guardrails.instructions.md` | Full guardrails (8 categories). | ❌ On demand (`/instructions`) |
+| `.github/prompts/*.prompt.md` | Reusable prompts (only available in VS Code, not in CLI). | N/A in CLI |
+| `docs/spec.md` | Project specification. The AI reads/writes it. | ❌ You ask for it |
+| `docs/decisions.md` | Architecture Decision Records (ADRs). | ❌ You ask for it |
+| `docs/session-log.md` | Session history — what happened, what's pending. | ❌ You ask for it |
+| `docs/team-roster.md` | Team members and contact info. | ❌ You ask for it |
+
+---
+
+## Step 5 — Open Copilot CLI
 
 ```bash
 copilot
 ```
 
-Copilot loads `AGENTS.md` and `.github/copilot-instructions.md` automatically.
-You'll notice it already knows your project name, stack and team rules.
+Copilot starts and automatically loads:
+- `AGENTS.md` — it knows which agents exist
+- `.github/copilot-instructions.md` — project context + critical guardrails
 
-### 2.2 Feature: `/agent` — See available agents
+You'll notice it already knows your project name, stack and team rules
+without you telling it anything.
 
-```text
-You: /agent
+---
+
+## Step 6 — Feature: `/agent` — List and switch agents
+
+### 6.1 List available agents
+
+Type:
+
+```
+/agent
 ```
 
-Copilot shows the list of agents from `AGENTS.md`:
+Copilot shows the team from `AGENTS.md`:
 
 ```
 Available agents:
@@ -122,318 +184,416 @@ Available agents:
   • QA           — QA Engineer
 ```
 
-### 2.3 Feature: Start a session (reading context)
+### 6.2 Switch to an agent
 
-```text
-You: Read docs/session-log.md, docs/spec.md and docs/decisions.md.
-     Summarize the current state of the project and suggest next steps.
+```
+/agent Architect
 ```
 
-Since the project is new, the agent will tell you the docs are empty and
-suggest writing a spec first. This is exactly what Understudy's
-**spec-first** rule enforces.
+Copilot adopts the Architect persona. From now on, it thinks like a
+solutions architect: system design, trade-offs, ADRs, Mermaid diagrams.
+
+### 6.3 What changes when you switch agents
+
+| Before `/agent` | After `/agent Architect` |
+|---|---|
+| General assistant | System designer |
+| No specific expertise | APIs, databases, cloud, DDD, CQRS |
+| No output format | Produces ADRs, Mermaid diagrams, alternatives tables |
+| No handoff awareness | Knows to consult Security, deliver to Backend |
 
 ---
 
-## Part 3 — Designing with the Architect
+## Step 7 — Feature: `/instructions` — Load role details
 
-### 3.1 Feature: `/agent Architect` — Switch agent
+The agent definition in `AGENTS.md` gives the personality. But the full
+expertise, working process and checklists are in the instruction files.
 
-```text
-You: /agent Architect
+```
+/instructions
 ```
 
-Copilot adopts the Architect's personality: system design, trade-offs, ADRs.
+You'll see a list of available instruction files:
 
-### 3.2 Feature: `/instructions` — Load detailed role instructions
-
-```text
-You: /instructions
+```
+1) architect.instructions.md
+2) backend.instructions.md
+3) devops.instructions.md
+4) frontend.instructions.md
+5) guardrails.instructions.md
+6) qa-engineer.instructions.md
+7) security.instructions.md
+...
 ```
 
-Select `architect.instructions.md`. This loads the Architect's full
-expertise list, working process and output standards into context.
+Select `architect.instructions.md`. This loads ~200 lines of detailed
+instructions into context: the Architect's full expertise list, step-by-step
+working process, output standards, and team interaction rules.
 
-### 3.3 Feature: `/model` — Choose the right model
-
-```text
-You: /model
-```
-
-Select **Claude Opus** (or the most capable model available). The Architect
-benefits from deeper reasoning for system design.
-
-> **Rule of thumb from `understudy.yaml`:**
-> - Architect / Security → Opus (complex reasoning)
-> - Backend / Frontend → Sonnet (good speed/quality balance)
-> - Quick tasks → Haiku (fast and cheap)
-
-### 3.4 Write the spec
-
-```text
-You: I need a REST API for task management. Features:
-     - User registration and login (JWT)
-     - CRUD tasks (title, description, status, due date)
-     - Assign tasks to users
-     - Filter by status, assignee, due date
-     - PostgreSQL database
-     - Docker for deployment
-
-     Write this as a formal spec in docs/spec.md following the team's
-     spec format.
-```
-
-The Architect writes `docs/spec.md` with requirements, constraints, NFRs
-and acceptance criteria.
-
-### 3.5 Design the architecture (ADR)
-
-```text
-You: Propose 2-3 architectural alternatives for this API.
-     Evaluate trade-offs (complexity, scalability, team familiarity).
-     Recommend one and document it as ADR-0001 in docs/decisions.md.
-```
-
-The Architect produces:
-- Alternative A: Express + Sequelize ORM
-- Alternative B: Express + raw SQL (pg)
-- Alternative C: Fastify + Prisma
-
-It recommends one, writes `docs/decisions.md` with the ADR in the standard
-format: Title, Status, Context, Options, Decision, Consequences.
+> **Tip:** You can load multiple instruction files. For example, load both
+> `architect.instructions.md` and `guardrails.instructions.md`.
 
 ---
 
-## Part 4 — Security review
+## Step 8 — Feature: `/model` — Choose the right model
 
-### 4.1 Switch to Security agent
+```
+/model
+```
 
-```text
-You: /agent Security
-You: /instructions
+Select the model best suited for the current task:
+
+| Task type | Recommended model | Why |
+|---|---|---|
+| Architecture design | Claude Opus / GPT-4o | Complex reasoning, trade-offs |
+| Security review | Claude Opus | Deep analysis, threat modeling |
+| Code implementation | Claude Sonnet / GPT-4o-mini | Good speed/quality balance |
+| Quick fixes, formatting | Claude Haiku | Fast and cheap |
+
+For the Architect, select **Claude Opus** (or the most powerful available).
+
+> These model recommendations come from `understudy.yaml`. You can
+> customize them per project.
+
+---
+
+## Step 9 — Session protocol: Start a session
+
+The session protocol gives the AI persistent memory across sessions.
+At the start of every work session, ask it to read the context files:
+
+```
+Read docs/session-log.md, docs/spec.md and docs/decisions.md.
+Summarize the current state of the project and suggest next steps.
+```
+
+Since this is a brand new project, the agent will report:
+- `docs/spec.md` is empty → needs requirements
+- `docs/decisions.md` is empty → no architecture yet
+- `docs/session-log.md` is empty → first session
+
+It will suggest: **write a spec first**. This is exactly what Understudy's
+**spec-first** team rule enforces.
+
+---
+
+## Step 10 — Write the project spec
+
+Still using the Architect agent:
+
+```
+I need a REST API for task management. Features:
+- User registration and login (JWT)
+- CRUD tasks (title, description, status, due date)
+- Assign tasks to users
+- Filter by status, assignee, due date
+- PostgreSQL database
+- Docker for deployment
+
+Write this as a formal spec in docs/spec.md. Include:
+- Functional requirements (numbered)
+- Non-functional requirements (performance, security)
+- Constraints
+- Acceptance criteria
+```
+
+The Architect writes a structured `docs/spec.md` with all sections.
+
+---
+
+## Step 11 — Design the architecture (ADR)
+
+```
+Propose 2-3 architectural alternatives for this API.
+Evaluate trade-offs: complexity, scalability, team familiarity, ORM overhead.
+Recommend one and document it as ADR-0001 in docs/decisions.md.
+Use the standard ADR format: Title, Status, Context, Options, Decision, Consequences.
+```
+
+The Architect produces something like:
+
+- **Option A:** Express + Sequelize ORM — easy, heavy
+- **Option B:** Express + raw SQL (pg) — light, more boilerplate
+- **Option C:** Express + Prisma — typed, modern, good DX
+
+It recommends one (e.g., Prisma) with justification and writes the ADR.
+
+---
+
+## Step 12 — Security review of the design
+
+### 12.1 Switch to the Security agent
+
+```
+/agent Security
+/instructions
 ```
 
 Select `security.instructions.md`.
 
-### 4.2 Feature: Security threat modeling
+### 12.2 Switch to a stronger model
 
-```text
-You: Review the architecture in docs/decisions.md ADR-0001.
-     Produce a threat model covering:
-     - Authentication flows (JWT)
-     - Input validation
-     - SQL injection surface
-     - Authorization (can user X edit user Y's tasks?)
-     - Secrets management
-     Add security requirements to docs/spec.md.
+```
+/model
 ```
 
-The Security agent reviews the design and adds constraints like:
+Select Opus (Security reviews benefit from deeper analysis).
+
+### 12.3 Run the review
+
+```
+Review the architecture in docs/decisions.md ADR-0001.
+Produce a threat model covering:
+- Authentication flows (JWT lifetime, refresh tokens)
+- Input validation surface
+- SQL injection risks
+- Authorization (can user X access user Y's tasks?)
+- Secrets management (where are credentials stored?)
+Add security requirements to docs/spec.md section "Non-functional requirements".
+```
+
+The Security agent adds constraints like:
 - JWT must expire in ≤ 1h
-- Refresh tokens stored httpOnly
+- Refresh tokens stored httpOnly, rotated on use
 - Parameterized queries only (no string concatenation)
-- Rate limiting on auth endpoints
-- Input validation with Joi/Zod
+- Rate limiting on auth endpoints (5 attempts/min)
+- Input validation with schema library (Zod/Joi)
 
 ---
 
-## Part 5 — Implementation with sub-agents
+## Step 13 — Implement with the Backend agent
 
-### 5.1 Feature: Sub-agents (parallel work)
+### 13.1 Switch agent and model
 
-This is one of Copilot CLI's most powerful features. You can ask it to
-split work across multiple internal agents that run in parallel.
-
-```text
-You: Implement TaskFlow following ADR-0001 and the security requirements.
-     Split the work:
-
-     Sub-agent 1 (Backend):
-     - Set up Express project structure
-     - Database schema (migrations)
-     - Auth endpoints (register, login, refresh)
-     - Task CRUD endpoints
-     - Input validation with Zod
-     - Error handling middleware
-
-     Sub-agent 2 (Frontend):
-     - Not applicable yet — skip for now
-
-     Sub-agent 3 (DevOps):
-     - Dockerfile
-     - docker-compose.yml (app + postgres)
-     - .env.example
-
-     Both must follow docs/decisions.md ADR-0001.
 ```
-
-Copilot launches internal task agents that work in parallel. You'll see
-them produce files simultaneously.
-
-### 5.2 Switch to Backend for refinement
-
-```text
-You: /agent Backend
-You: /instructions
+/agent Backend
+/instructions
 ```
 
 Select `backend.instructions.md`.
 
-```text
-You: Review the generated code. Ensure:
-     - All endpoints have input validation
-     - Error responses follow a consistent format
-     - Database queries use parameterized statements
-     - Auth middleware protects /tasks routes
+```
+/model
 ```
 
-### 5.3 Feature: `/diff` — Review changes
+Select **Sonnet** (good speed/quality for implementation).
 
-```text
-You: /diff
+### 13.2 Implement
+
+```
+Implement the TaskFlow API following ADR-0001 and the security requirements in docs/spec.md.
+Set up:
+- Express project structure (src/controllers, src/services, src/middleware)
+- Database schema with Prisma (users, tasks tables)
+- Auth endpoints: POST /register, POST /login, POST /refresh
+- Task CRUD: GET/POST/PUT/DELETE /tasks
+- Auth middleware protecting /tasks routes
+- Input validation with Zod
+- Error handling middleware (consistent JSON response format)
+- Dockerfile + docker-compose.yml (app + postgres)
+- .env.example (no real secrets)
 ```
 
-Shows all pending file modifications. Review before accepting.
+The Backend agent creates all the files.
 
 ---
 
-## Part 6 — QA: Testing
+## Step 14 — Feature: `/diff` — Review pending changes
 
-### 6.1 Switch to QA
+After the agent writes files, review what changed:
 
-```text
-You: /agent QA
-You: /instructions
+```
+/diff
+```
+
+This shows all pending file modifications. Review before accepting.
+
+---
+
+## Step 15 — Feature: Sub-agents (parallel work)
+
+This is one of Copilot CLI's most powerful features — and it's **exclusive
+to the CLI** (not available in VS Code, Claude Code or Cursor).
+
+You can ask Copilot to split work into parallel internal agents:
+
+```
+Implement these in parallel:
+
+Sub-agent 1 (Backend):
+- Complete the task filtering logic (by status, assignee, due date)
+- Add pagination (limit/offset)
+
+Sub-agent 2 (DevOps):
+- Create .github/workflows/ci.yml (lint + test + build Docker)
+- Add a test docker-compose with PostgreSQL service
+
+Both must follow docs/decisions.md ADR-0001.
+```
+
+Copilot launches internal task agents that work simultaneously and merge
+their results. This saves wall-clock time when tasks are independent.
+
+> **When to use sub-agents:**
+> - Backend + Frontend implementing simultaneously
+> - Implementation + Tests in parallel
+> - Code + Documentation at the same time
+>
+> **When NOT to use them:**
+> - Tasks that depend on each other
+> - When you need to review intermediate steps
+
+---
+
+## Step 16 — QA: Writing tests
+
+### 16.1 Switch to QA
+
+```
+/agent QA
+/instructions
 ```
 
 Select `qa-engineer.instructions.md`.
 
-### 6.2 Write tests
+### 16.2 Write tests
 
-```text
-You: Create a test plan for TaskFlow. Then implement:
-     1. Unit tests for auth service (register, login, token validation)
-     2. Unit tests for task CRUD operations
-     3. Integration tests for the full API (using supertest)
-     4. Edge cases: expired tokens, invalid input, unauthorized access
-
-     Use Jest as the test framework.
 ```
+Create a test plan for TaskFlow. Then implement:
+1. Unit tests for auth service (register, login, token validation)
+2. Unit tests for task CRUD operations
+3. Integration tests for the full API (using supertest)
+4. Edge cases: expired tokens, invalid input, unauthorized access
 
-The QA agent produces:
-- `tests/unit/auth.test.js`
-- `tests/unit/tasks.test.js`
-- `tests/integration/api.test.js`
-- A test plan summary
-
----
-
-## Part 7 — DevOps: CI/CD
-
-### 7.1 Switch to DevOps
-
-```text
-You: /agent DevOps
-You: /instructions
-```
-
-### 7.2 Add CI pipeline
-
-```text
-You: Create a GitHub Actions workflow for TaskFlow:
-     - Lint (ESLint)
-     - Unit tests
-     - Integration tests (needs PostgreSQL service)
-     - Build Docker image
-     - Push to GHCR on main branch
-
-     Follow the security guardrails (no secrets in code, use GitHub
-     Secrets).
+Use Jest as the test framework. Follow the test plan.
 ```
 
 ---
 
-## Part 8 — Guardrails in action
+## Step 17 — DevOps: CI/CD
 
-### 8.1 What guardrails do
+### 17.1 Switch to DevOps
 
-Guardrails are **always active** — Copilot loads them from
-`.github/copilot-instructions.md` (critical subset) and
-`guardrails.instructions.md` (full details).
-
-### 8.2 Try to violate a guardrail
-
-```text
-You: Add a hardcoded database password in the config file.
-     Use a literal string as the password.
+```
+/agent DevOps
+/instructions
 ```
 
-The agent will **refuse** and explain:
+Select `devops.instructions.md`.
 
-> ⚠️ Guardrail violation: Security category — "No secrets, no bypass,
-> mandatory input validation". Credentials must come from environment
-> variables or a secrets manager, never hardcoded.
+### 17.2 Add CI pipeline
 
-It will suggest using `process.env.DATABASE_PASSWORD` instead.
-
-### 8.3 Try another violation
-
-```text
-You: Delete all migration files and the entire tests/ folder.
 ```
+Create a GitHub Actions workflow for TaskFlow:
+- Lint (ESLint)
+- Unit tests
+- Integration tests (needs PostgreSQL service)
+- Build Docker image
+- Push to GHCR on main branch
 
-The agent will **refuse** or request confirmation:
-
-> ⚠️ Guardrail violation: Destructive operations — "PM confirmation before
-> deleting, purging or revoking". This is a bulk destructive operation.
-> Please confirm with the project manager before proceeding.
-
-### 8.4 Scope guardrail
-
-```text
-You: /agent Frontend
-You: Modify the database schema in src/db/migrations/
+Follow the security guardrails: no secrets in code, use GitHub Secrets.
 ```
-
-The Frontend agent will note that database schema is Backend's domain and
-either defer or ask for justification.
 
 ---
 
-## Part 9 — Token management
+## Step 18 — Guardrails in action
 
-### 9.1 Feature: `/compact` — Compress conversation
+Guardrails are safety rules that the AI always respects. They are loaded from
+`.github/copilot-instructions.md` (critical subset, always active) and from
+`guardrails.instructions.md` (full details, loaded via `/instructions`).
 
-After a long session, your token count increases. Use:
+There are 8 categories:
 
-```text
-You: /compact
+| # | Category | What it protects |
+|---|---|---|
+| 1 | Security | No secrets in code, mandatory input validation |
+| 2 | Scope | Each agent owns specific files, must justify crossing |
+| 3 | Process | Spec-first (no code without spec) |
+| 4 | Destructive | No bulk deletes without PM confirmation |
+| 5 | Data/PII | No real data, synthetic only |
+| 6 | Quality | Self-review, tests, proper naming |
+| 7 | Environments | dev → staging → prod promotion order |
+| 8 | Documentation | ADRs required, session-log updated |
+
+### 18.1 Exercise: Security guardrail
+
+```
+Add a hardcoded database password in the config file.
+Use a literal string as the password.
+```
+
+The agent **refuses**:
+
+> ⚠️ Guardrail: Security — "No secrets, no bypass." Credentials must come
+> from environment variables. I'll use `process.env.DATABASE_PASSWORD`.
+
+### 18.2 Exercise: Destructive guardrail
+
+```
+Delete all migration files and the entire tests/ folder.
+```
+
+The agent **refuses** or requests confirmation:
+
+> ⚠️ Guardrail: Destructive operations — "PM confirmation before deleting."
+
+### 18.3 Exercise: Scope guardrail
+
+```
+/agent Frontend
+Modify the database schema in src/db/schema.prisma.
+```
+
+The Frontend agent defers:
+
+> ⚠️ Guardrail: Scope — Database files are Backend's responsibility.
+
+### 18.4 Exercise: Process guardrail
+
+```
+Add a WebSocket real-time notification feature. Just code it, no design.
+```
+
+The agent pushes back:
+
+> ⚠️ Guardrail: Process — Spec-first. Update docs/spec.md first.
+
+---
+
+## Step 19 — Feature: `/compact` — Save tokens
+
+After a long conversation, your token count grows. Compress it:
+
+```
+/compact
 ```
 
 This compresses the conversation history while preserving key decisions.
-Your actual project state is safe because it lives in `docs/session-log.md`.
-
-### 9.2 Feature: `/context` — Check usage
-
-```text
-You: /context
-```
-
-Shows current token usage and which files are loaded. Useful to understand
-if you're approaching limits.
+Your project state is safe in the `docs/` files.
 
 ---
 
-## Part 10 — Ending the session
+## Step 20 — Feature: `/context` — Check token usage
 
-### 10.1 Update the session log
+```
+/context
+```
 
-```text
-You: Update docs/session-log.md with:
-     - What we accomplished today
-     - Decisions made (reference ADR-0001)
-     - Open items / next steps
-     - Any blockers
+Shows current token usage, which files are loaded, and how much room is
+left. Useful to decide whether to `/compact` or start a new session.
+
+---
+
+## Step 21 — Session protocol: End the session
+
+At the end of every work session, update the session log:
+
+```
+Update docs/session-log.md with:
+- What we accomplished today
+- Decisions made (reference ADR numbers)
+- Open items / next steps
+- Any blockers
 ```
 
 The agent writes a structured entry:
@@ -446,41 +606,40 @@ The agent writes a structured entry:
 - Designed architecture (ADR-0001: Express + Prisma)
 - Security review and threat model
 - Implemented auth + task CRUD
-- Docker setup (Dockerfile + docker-compose)
+- Docker setup
 - Test suite (unit + integration)
-- CI/CD pipeline (GitHub Actions)
+- CI pipeline
 
 ### Decisions
 - ADR-0001: Express + Prisma over raw SQL (DX, type safety)
 
 ### Next steps
-- Frontend (React)
 - E2E tests
+- Frontend (React)
 - Production deployment manifests
 
 ### Blockers
 - None
 ```
 
-### 10.2 Why this matters
+### Why this matters
 
-Next time you (or a teammate) start a session, the AI reads
-`session-log.md` and immediately knows the full project history — no need
-to re-explain anything. This is Understudy's **persistent memory**.
+Next time you start a session and ask the AI to read `docs/session-log.md`,
+it immediately knows the full project history — no need to re-explain.
+This is Understudy's **persistent memory**.
 
 ---
 
-## Part 11 — Adding team members
+## Step 22 — Feature: `--add-member` — Extend the team
 
-### 11.1 Feature: `--add-member`
-
-Need a Data Engineer for analytics pipelines later?
+Need a Data Engineer for analytics pipelines?
 
 ```bash
+# Exit the Copilot session first (Ctrl+C), then:
 understudy --add-member
 ```
 
-Choose from the catalog:
+You'll see a menu:
 
 ```
 Available roles:
@@ -492,70 +651,69 @@ Available roles:
   ...
 ```
 
-Select one and it's deployed to `.github/instructions/` and added to
-`AGENTS.md`. Next time you open Copilot, `/agent` will show the new member.
+Select one. Understudy deploys it to `.github/instructions/` and adds it
+to `AGENTS.md`. Next time you open Copilot, `/agent` shows the new member.
 
-### 11.2 Feature: `--create-role`
+---
 
-Need a role that doesn't exist?
+## Step 23 — Feature: `--create-role` — Create a custom role
+
+Need a role that doesn't exist in the catalog?
 
 ```bash
 understudy --create-role
 ```
 
 The wizard asks for: name, title, description, expertise areas, motto.
-It generates a `.instructions.md` file in `roles/` for reuse across all
-your projects.
+It generates a `.instructions.md` file saved in Understudy's `roles/`
+folder. This role is available for **all future projects**.
 
 ---
 
-## Part 12 — Caveman mode (optional)
+## Step 24 — Caveman mode (optional)
 
-### 12.1 What is Caveman?
+Caveman mode makes the AI respond in a token-efficient style: it drops
+filler words, articles, and unnecessary prose while keeping code, paths
+and technical accuracy intact. Saves 30-50% tokens.
 
-A token-efficient communication style. The AI drops filler words, articles,
-and unnecessary prose while preserving code, paths and technical accuracy.
-Saves 30-50% tokens per response.
-
-### 12.2 Enable it
+### 24.1 Enable it
 
 ```bash
 understudy --caveman
 ```
 
-This deploys:
-- `.github/instructions/caveman.instructions.md` (role, `applyTo: "**"`)
+This deploys `.github/instructions/caveman.instructions.md` with
+`applyTo: "**"` (always active).
 
-### 12.3 Use it
+### 24.2 See the difference
 
-After enabling, the AI's responses become shorter:
+**Normal response:**
+> I'll create a new Express middleware function that validates the JWT
+> token from the Authorization header and attaches the decoded user
+> payload to the request object for use in downstream handlers.
 
-**Normal:**
-> I'll create a new Express middleware function that validates the JWT token
-> from the Authorization header and attaches the decoded user payload to
-> the request object.
+**Caveman response:**
+> Creating JWT middleware → validates `Authorization` header, attaches
+> decoded user to `req.user`.
 
-**Caveman:**
-> Creating JWT middleware → validates Authorization header, attaches decoded
-> user to `req.user`.
-
-Same accuracy, fewer tokens.
+Same technical accuracy, ~40% fewer tokens.
 
 ---
 
-## Quick reference card
+## Complete command reference
 
 | Feature | Command / Action |
 |---|---|
-| Switch agent | `/agent <name>` |
+| List agents | `/agent` |
+| Switch to agent | `/agent <Name>` |
 | Load role details | `/instructions` → select file |
 | Change model | `/model` → select |
-| Compress tokens | `/compact` |
-| See changes | `/diff` |
+| Compress conversation | `/compact` |
+| See pending changes | `/diff` |
 | Check token usage | `/context` |
-| Parallel work | Ask for sub-agents in prompt |
-| Start session | Read `docs/session-log.md`, `spec.md`, `decisions.md` |
-| End session | Update `docs/session-log.md` |
+| Parallel work | Ask for sub-agents in prompt text |
+| Start a session | Ask to read `docs/session-log.md`, `spec.md`, `decisions.md` |
+| End a session | Ask to update `docs/session-log.md` |
 | Add team member | `understudy --add-member` (in terminal) |
 | Create new role | `understudy --create-role` (in terminal) |
 | Enable caveman | `understudy --caveman` (in terminal) |
@@ -563,15 +721,31 @@ Same accuracy, fewer tokens.
 
 ---
 
-## Next steps
+## Tips
 
-- Try the [VS Code Copilot tutorial](vscode-copilot-tutorial.md) — same
-  project, different workflow (auto-applied instructions, prompt files).
-- Read [Cross-Platform Workflows](../08-cross-platform-workflows.md) to
-  combine CLI and VS Code in the same project.
-- See [Configuration Reference](../09-configuration.md) to customize
-  models, guardrails mode and role settings.
+- Use **Opus** for Architect and Security tasks (complex reasoning).
+- Use **Sonnet** for Backend/Frontend/QA (good speed/quality).
+- Use **Haiku** for quick DevOps tasks or formatting.
+- Always start sessions by reading `docs/session-log.md`.
+- Always end sessions by updating `docs/session-log.md`.
+- Use `/compact` when the conversation gets long.
+- Guardrails protect you even if you forget — they're always in context.
+- The prompt files (`.github/prompts/`) are for VS Code only. In the CLI,
+  replicate them by asking the AI to read docs and summarize manually.
 
 ---
 
-[← Back to tutorials index](README.md) · [Next: VS Code Copilot →](vscode-copilot-tutorial.md)
+## Troubleshooting
+
+| Problem | Solution |
+|---|---|
+| `/agent` shows no agents | Verify `AGENTS.md` exists in the project root |
+| Agent ignores guardrails | Load `guardrails.instructions.md` with `/instructions` |
+| Token limit reached | Use `/compact` or start a new session |
+| Wrong model for the task | Use `/model` to switch |
+| Sub-agents don't run | Rephrase: explicitly say "use sub-agents" or "run in parallel" |
+| `understudy` command not found | Re-open terminal or `source ~/.bashrc` |
+
+---
+
+[Back to tutorials index](README.md)

--- a/docs/tutorials/cursor-tutorial.md
+++ b/docs/tutorials/cursor-tutorial.md
@@ -1,41 +1,111 @@
 # Tutorial: Cursor — Full Feature Walkthrough
 
-> A hands-on guide that walks you through **every feature** Understudy
-> provides for Cursor, using the same TaskFlow project from the previous
-> tutorials.
+> A complete, self-contained guide that walks you step by step through
+> **every feature** Understudy provides for Cursor.
+> You do not need to read any other tutorial before this one.
 
-## Prerequisites
+---
 
-- Cursor installed.
-- Understudy installed.
+## What you will learn
 
-If starting fresh:
+By the end of this tutorial you will have used:
+
+- Rules (MDC format) — 4 types: always-apply, glob-based, agent-requested, manual
+- Agent panel — visual agent switching
+- Model in frontmatter — per-agent model assignment
+- Commands — slash commands in chat
+- Guardrails — always-active safety rules
+- Custom rules — create your own auto-attached rules
+- Custom agents — add new roles
+- Custom commands — create your own workflows
+- Session protocol — persistent memory across sessions
+- `--add-member` / `--create-role` — extend the team
+- Caveman mode — compress/restore, reinforcement rule
+
+---
+
+## What you need before starting
+
+| Requirement | How to get it |
+|---|---|
+| Cursor | [cursor.com](https://cursor.com) |
+| `bash` ≥ 4 | Comes with Linux/macOS. On Windows use Git Bash or WSL |
+| `git` | Any recent version |
+
+---
+
+## Step 1 — Install Understudy
+
+Open a terminal and run:
 
 ```bash
-mkdir taskflow && cd taskflow && git init
-understudy          # select "Cursor" platform
-cursor .            # open the project
+curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash
+```
+
+This downloads the latest release, installs it to `~/.understudy/` and adds
+the `understudy` command to your PATH.
+
+Close and re-open your terminal (or `source ~/.bashrc`) so the command is
+available.
+
+Verify:
+
+```bash
+understudy --help
 ```
 
 ---
 
-## What makes Cursor unique?
+## Step 2 — Create the example project
 
-Cursor uses two complementary systems that differ from other platforms:
+We will build **TaskFlow** — a simple task management REST API. The project
+is intentionally simple so you can focus on learning the AI workflow.
 
-| Concept | What it means |
-|---|---|
-| **Rules** (`.mdc` files) | Global instructions, always active or auto-attached by glob |
-| **Agents** (`.md` files) | Role-based personas invoked from the Agent panel |
-| **Commands** | Slash commands invoked from chat |
-| **Model in frontmatter** | Each agent auto-selects its model (`auto`, `fast`, specific) |
-| **Glob-based auto-attach** | Rules load when you edit matching files (like VS Code's `applyTo`) |
+```bash
+mkdir taskflow
+cd taskflow
+git init
+```
 
 ---
 
-## Part 1 — Understanding the generated files
+## Step 3 — Deploy Understudy into the project
 
-After running `understudy`, your project has:
+Run the wizard:
+
+```bash
+understudy
+```
+
+The wizard asks 9 questions. Answer like this:
+
+| # | Question | What to enter |
+|---|---|---|
+| 1 | Project name | `taskflow` |
+| 2 | Short description | `Task management REST API` |
+| 3 | Project manager | Your name |
+| 4 | Tech stack | `Node.js + Express + PostgreSQL + Docker` |
+| 5 | Repository URL | `https://github.com/you/taskflow` (or leave blank) |
+| 6 | Guardrails mode | `split` (press Enter for default) |
+| 7 | Platforms | Select **Cursor** |
+| 8 | Git: commit files? | `y` |
+| 9 | Git: local-only config? | `n` |
+
+> **Shortcut:** `understudy --here` auto-infers all values from your repo.
+
+---
+
+## Step 4 — Open the project in Cursor
+
+```bash
+cursor .
+```
+
+---
+
+## Step 5 — Verify the generated files
+
+In the Cursor file explorer you should see:
 
 ```
 .cursor/
@@ -45,22 +115,48 @@ After running `understudy`, your project has:
 ├── agents/
 │   ├── architect.md
 │   ├── backend.md
-│   ├── frontend.md
 │   ├── devops.md
-│   ├── security.md
-│   ├── qa-engineer.md
+│   ├── frontend.md
 │   ├── git-specialist.md           ← Auto-deployed
-│   └── repo-documenter.md          ← Auto-deployed
+│   ├── qa-engineer.md
+│   ├── repo-documenter.md          ← Auto-deployed
+│   └── security.md
 └── commands/
     └── understudy.md               ← /understudy command
 docs/
-├── spec.md
 ├── decisions.md
 ├── session-log.md
+├── spec.md
 └── team-roster.md
 ```
 
-### 1.1 Feature: Rules (MDC format)
+### What each file does
+
+| File/folder | Purpose | Loaded automatically? |
+|---|---|---|
+| `.cursor/rules/understudy-global.mdc` | Global project instructions. Always in context. | ✅ Yes, always |
+| `.cursor/rules/guardrails.mdc` | Full guardrails (8 categories). Always in context. | ✅ Yes, always |
+| `.cursor/agents/<role>.md` | Agent definition (name, description, model). | ❌ When selected in Agent panel |
+| `.cursor/commands/<name>.md` | Slash commands. | ❌ When you type `/<name>` |
+| `docs/*.md` | Persistent memory (spec, decisions, session log). | ❌ You ask or create commands |
+
+---
+
+## Step 6 — Feature: Rules (MDC format)
+
+Cursor rules use **MDC** — Markdown files with YAML frontmatter, extension
+`.mdc`, stored in `.cursor/rules/`.
+
+### 6.1 The 4 types of rules
+
+| Type | Frontmatter | When loaded | Token cost |
+|---|---|---|---|
+| **Always-apply** | `alwaysApply: true` | Every session, unconditionally | Constant |
+| **Auto-attached** | `globs: "src/**/*.ts"` | When you edit a matching file | Per-file |
+| **Agent-requested** | `description:` only | Cursor decides based on context | On-demand |
+| **Manual** | Empty frontmatter | Only if you reference it | On-demand |
+
+### 6.2 Always-apply rules
 
 Open `.cursor/rules/understudy-global.mdc`:
 
@@ -76,10 +172,10 @@ alwaysApply: true
 # ...
 ```
 
-Key: `alwaysApply: true` means this rule is loaded in **every single
+`alwaysApply: true` means this rule is loaded in **every single
 conversation** without you doing anything.
 
-### 1.2 Feature: Guardrails rule
+### 6.3 Guardrails rule
 
 Open `.cursor/rules/guardrails.mdc`:
 
@@ -90,16 +186,40 @@ alwaysApply: true
 ---
 
 # 🛡️ Guardrails
-## 1. Security
-- Never hardcode secrets...
-## 2. Scope
-- Respect file ownership...
+## 1. Security — No secrets, no bypass...
+## 2. Scope — Each agent owns specific files...
 ...
 ```
 
 Also `alwaysApply: true` — guardrails are always in context.
 
-### 1.3 Feature: Agent files
+---
+
+## Step 7 — Feature: Agent panel
+
+### 7.1 Open the Agent panel
+
+In Cursor, open the **Agent panel** (right sidebar or command palette).
+You'll see all agents from `.cursor/agents/`:
+
+```
+Available agents:
+  architect    — Solutions Architect
+  backend      — Backend Developer
+  frontend     — Frontend Developer
+  devops       — DevOps Engineer
+  security     — Security Expert
+  qa-engineer  — QA Engineer
+  git-specialist
+  repo-documenter
+```
+
+### 7.2 Select an agent
+
+Click **architect** in the Agent panel. The chat now uses the Architect's
+personality, expertise and model.
+
+### 7.3 Agent file format
 
 Open `.cursor/agents/architect.md`:
 
@@ -117,45 +237,211 @@ You are the Solutions Architect...
 
 ## Expertise
 - System design, APIs, databases...
+
+## How you work
+1. Read docs/spec.md...
+2. Propose 2-3 alternatives...
+3. Recommend one...
+4. Document in docs/decisions.md...
 ```
 
-The `model` field controls which model Cursor uses when this agent is
-active. Options:
+The `model` field controls which model Cursor uses:
 - `auto` — Cursor's default model
-- `fast` — fastest available model
+- `fast` — fastest available
 - `claude-opus-4` — specific model (if available)
 
 ---
 
-## Part 2 — The four types of rules
+## Step 8 — Start a session
 
-### 2.1 Always-apply rules
+Cursor doesn't have a built-in `/start-session` like the prompt files in
+VS Code. But you can easily create one (we'll do that in Step 16).
 
-```yaml
----
-alwaysApply: true
----
+For now, manually ask in chat:
+
+```
+Read docs/session-log.md, docs/spec.md, docs/decisions.md and
+docs/team-roster.md. Summarize the current state and suggest next steps.
 ```
 
-Loaded unconditionally. Used for:
-- Global project instructions (`understudy-global.mdc`)
-- Guardrails (`guardrails.mdc`)
+Since this is a new project, Cursor reports empty docs and suggests
+writing a spec first.
 
-**Cost:** Consumes tokens every session. Keep them concise.
-
-### 2.2 Auto-attached rules (glob-based)
-
-```yaml
 ---
-description: "React component standards"
-globs: "src/components/**/*.tsx,src/components/**/*.css"
----
+
+## Step 9 — Design with the Architect agent
+
+### 9.1 Select the Architect
+
+Agent panel → click **architect**.
+
+### 9.2 Write the spec
+
+```
+I need a REST API for task management. Features:
+- User registration and login (JWT)
+- CRUD tasks (title, description, status, due date)
+- Assign tasks to users
+- Filter by status, assignee, due date
+- PostgreSQL database, Docker deployment
+
+Write a formal spec in docs/spec.md with:
+- Functional requirements (numbered)
+- Non-functional requirements (performance, security)
+- Constraints
+- Acceptance criteria
 ```
 
-Loaded only when you edit files matching the glob pattern. This is
-Cursor's equivalent of VS Code's `applyTo`.
+### 9.3 Design the architecture
 
-**Exercise — Create an auto-attached rule:**
+```
+Propose 2-3 architectural alternatives for this API.
+Evaluate trade-offs: complexity, scalability, DX.
+Recommend one and document it as ADR-0001 in docs/decisions.md.
+Use the standard ADR format: Title, Status, Context, Options,
+Decision, Consequences.
+```
+
+---
+
+## Step 10 — Security review
+
+### 10.1 Switch to Security
+
+Agent panel → click **security**.
+
+### 10.2 Run the review
+
+```
+Review the architecture in docs/decisions.md ADR-0001.
+Produce a threat model covering:
+- JWT auth flows (lifetime, refresh tokens)
+- Input validation surface
+- SQL injection risks
+- Authorization (user X can't access user Y's tasks)
+- Secrets management
+Add security requirements to docs/spec.md.
+```
+
+---
+
+## Step 11 — Implement with the Backend agent
+
+### 11.1 Switch to Backend
+
+Agent panel → click **backend**.
+
+### 11.2 Implement
+
+```
+Implement TaskFlow following ADR-0001 and security requirements.
+Set up:
+- Express project structure (src/controllers, src/services, src/middleware)
+- Database schema with Prisma
+- Auth endpoints: POST /register, POST /login, POST /refresh
+- Task CRUD: GET/POST/PUT/DELETE /tasks
+- Auth middleware protecting /tasks routes
+- Input validation with Zod
+- Error handling middleware
+- Dockerfile + docker-compose.yml
+- .env.example (no real secrets)
+```
+
+### 11.3 Switch agents mid-session
+
+You can switch freely without losing context:
+
+Agent panel → click **devops**:
+
+```
+Add a GitHub Actions workflow:
+- Lint, unit tests, integration tests (PostgreSQL service)
+- Build and push Docker image to GHCR
+```
+
+Agent panel → click **qa-engineer**:
+
+```
+Write tests for TaskFlow:
+1. Unit tests for auth service
+2. Unit tests for task CRUD
+3. Integration tests (supertest)
+4. Edge cases: expired tokens, invalid input, unauthorized access
+Use Jest.
+```
+
+---
+
+## Step 12 — Guardrails in action
+
+Guardrails are always active because `guardrails.mdc` uses
+`alwaysApply: true`. There are 8 categories:
+
+| # | Category | What it protects |
+|---|---|---|
+| 1 | Security | No secrets in code, mandatory input validation |
+| 2 | Scope | Each agent owns specific files |
+| 3 | Process | Spec-first (no code without spec) |
+| 4 | Destructive | No bulk deletes without PM confirmation |
+| 5 | Data/PII | No real data, synthetic only |
+| 6 | Quality | Self-review, tests, proper naming |
+| 7 | Environments | dev → staging → prod promotion order |
+| 8 | Documentation | ADRs required, session-log updated |
+
+### 12.1 Exercise: Security guardrail
+
+Select the **backend** agent and ask:
+
+```
+Store the JWT secret directly in the code as a string constant.
+```
+
+Cursor refuses:
+
+> 🛡️ Guardrail: Security — No secrets in code. I'll use
+> `process.env.JWT_SECRET` and add it to `.env.example`.
+
+### 12.2 Exercise: Process guardrail
+
+```
+Add a WebSocket chat feature. Just code it, skip the design.
+```
+
+Cursor pushes back:
+
+> 🛡️ Guardrail: Process — Spec-first. Update docs/spec.md first,
+> create an ADR, then implement.
+
+### 12.3 Exercise: Destructive guardrail
+
+```
+Delete the entire tests/ directory and all migration files.
+```
+
+Cursor flags:
+
+> ⚠️ Guardrail: Destructive — requires PM confirmation before bulk deletes.
+
+### 12.4 Exercise: Scope guardrail
+
+Select the **frontend** agent:
+
+```
+Modify the database migration to add a new column.
+```
+
+Frontend defers:
+
+> 🛡️ Scope: Database migrations are Backend's responsibility.
+
+---
+
+## Step 13 — Feature: Create auto-attached rules
+
+This is where Cursor shines. You can create rules that automatically load
+when you edit files matching a glob pattern.
+
+### 13.1 Backend coding standards
 
 Create `.cursor/rules/backend-standards.mdc`:
 
@@ -168,120 +454,89 @@ globs: "src/services/**/*.ts,src/controllers/**/*.ts"
 - Use dependency injection (constructor parameters)
 - All public methods must have JSDoc
 - Error handling: throw typed AppError, never raw Error
-- Database queries: always use parameterized statements
+- Database queries: always parameterized
 - Input validation: Zod schemas at the controller boundary
 ```
 
-Now when you open any file in `src/services/` or `src/controllers/`, this
-rule activates automatically.
+Now when you open any file in `src/services/`, this rule activates.
 
-### 2.3 Agent-requested rules
+### 13.2 Testing standards
 
-```yaml
----
-description: "Database migration conventions"
----
-```
-
-No `alwaysApply`, no `globs` — just a description. Cursor reads the
-description and **decides** whether to apply the rule based on your
-current conversation context.
-
-### 2.4 Manual rules
+Create `.cursor/rules/testing-standards.mdc`:
 
 ```yaml
 ---
----
-```
-
-Neither auto-applied nor auto-attached. Only loaded if you explicitly
-reference the rule in chat.
-
-### 2.5 Summary table
-
-| Rule type | Frontmatter | When loaded | Token cost |
-|---|---|---|---|
-| Always | `alwaysApply: true` | Every session | Constant |
-| Auto-attached | `globs: "pattern"` | Matching file open | Per-file |
-| Agent-requested | `description:` only | Cursor decides | On-demand |
-| Manual | Empty frontmatter | You reference it | On-demand |
-
+description: "Testing standards for TaskFlow"
+globs: "tests/**/*.ts,**/*.test.ts,**/*.spec.ts"
 ---
 
-## Part 3 — Using the Agent panel
-
-### 3.1 Feature: Agent panel
-
-In Cursor, open the **Agent panel** (usually in the right sidebar or via
-the command palette). You'll see all agents from `.cursor/agents/`:
-
-```
-Available agents:
-  architect    — Solutions Architect
-  backend      — Backend Developer
-  frontend     — Frontend Developer
-  devops       — DevOps Engineer
-  security     — Security Expert
-  qa-engineer  — QA Engineer
-  git-specialist
-  repo-documenter
+- Framework: Jest + Supertest
+- Arrange-Act-Assert pattern
+- Mock external services (database, email)
+- Naming: describe('<module>') → it('should <behavior>')
+- Coverage target: 80% lines, 90% branches for critical paths
 ```
 
-### 3.2 Select an agent
+### 13.3 API conventions
 
-Click **architect** in the Agent panel. The chat now uses the Architect's
-personality, expertise and model.
+Create `.cursor/rules/api-conventions.mdc`:
 
-```text
-You: Design a REST API for task management. Users can create, read,
-     update and delete tasks. Tasks have: title, description, status
-     (todo/in-progress/done), due date, assignee.
-     Write the spec in docs/spec.md and an ADR in docs/decisions.md.
+```yaml
+---
+description: "REST API conventions for TaskFlow"
+globs: "src/controllers/**/*.ts,src/routes/**/*.ts"
+---
+
+- All endpoints return { data, error, meta } envelope
+- HTTP codes: 200, 201, 400, 401, 403, 404, 500
+- Pagination: ?page=1&limit=20 → meta has total, pages
+- Dates in ISO 8601 (UTC)
 ```
 
-The Architect:
-1. Asks clarifying questions about scale, auth, etc.
-2. Proposes 2-3 alternatives
-3. Recommends one
-4. Writes spec + ADR
+### 13.4 Excluding patterns
 
-### 3.3 Switch agents mid-session
+Use `!` to exclude:
 
-Click **security** in the Agent panel:
-
-```text
-You: Review ADR-0001 in docs/decisions.md. Threat model the JWT auth
-     flow and suggest hardening measures.
+```yaml
+globs: "src/**/*.ts,!src/**/*.test.ts"
 ```
 
-Click **backend**:
-
-```text
-You: Implement the task API following ADR-0001. Set up Express + Prisma +
-     Zod validation. Include auth middleware.
-```
-
-You can switch agents freely — the conversation context is preserved.
-Each agent uses its configured model automatically.
+This applies to all `.ts` files **except** tests.
 
 ---
 
-## Part 4 — Commands
+## Step 14 — How rules stack
 
-### 4.1 Feature: `/understudy` command
+When you edit a file, Cursor combines all matching rules:
 
-```text
-You: /understudy
+```
+Active context = always-apply rules + matching glob rules + active agent
 ```
 
-Cursor explains all available agents, rules, the recommended workflow and
-how to use the system. Good for onboarding.
+For example, editing `src/services/auth.ts` with the Backend agent:
 
-### 4.2 Creating custom commands
+1. `understudy-global.mdc` loads (always-apply)
+2. `guardrails.mdc` loads (always-apply)
+3. `backend-standards.mdc` loads (glob matches `src/services/**`)
+4. Backend agent persona loads (from Agent panel)
 
-Add a file to `.cursor/commands/`:
+All 4 are active simultaneously → precise, context-aware responses.
 
-**`.cursor/commands/start-session.md`:**
+---
+
+## Step 15 — Feature: Commands
+
+### 15.1 Built-in command
+
+```
+/understudy
+```
+
+Cursor explains all agents, rules, workflow and how to use them.
+
+### 15.2 Create a start-session command
+
+Create `.cursor/commands/start-session.md`:
 
 ```markdown
 Read docs/session-log.md, docs/spec.md, docs/decisions.md and
@@ -292,7 +547,9 @@ docs/team-roster.md. Summarize:
 - Suggested next steps
 ```
 
-**`.cursor/commands/end-session.md`:**
+### 15.3 Create an end-session command
+
+Create `.cursor/commands/end-session.md`:
 
 ```markdown
 Update docs/session-log.md with a new entry for today:
@@ -302,14 +559,7 @@ Update docs/session-log.md with a new entry for today:
 - Blockers (if any)
 ```
 
-Now you can use:
-
-```text
-You: /start-session
-You: /end-session
-```
-
-### 4.3 More useful custom commands
+### 15.4 More useful commands
 
 **`.cursor/commands/design-feature.md`:**
 
@@ -336,247 +586,54 @@ Act as the Security agent. Review all recent changes for:
 Report findings with severity (Critical/High/Medium/Low).
 ```
 
----
+Now you can use:
 
-## Part 5 — Guardrails in action
-
-### 5.1 Always-active protection
-
-Since `guardrails.mdc` uses `alwaysApply: true`, the guardrails are
-enforced in every single conversation, regardless of which agent is active.
-
-### 5.2 Exercise: Security guardrail
-
-Select the **backend** agent and ask:
-
-```text
-You: Store the JWT secret directly in the code:
-     const JWT_SECRET = "<REDACTED>"
 ```
-
-Cursor refuses:
-
-> 🛡️ Guardrail violation: Security — "No secrets in code". The JWT
-> secret must come from an environment variable. I'll use
-> `process.env.JWT_SECRET` and add it to `.env.example`.
-
-### 5.3 Exercise: Process guardrail
-
-```text
-You: Add a WebSocket real-time feature. Just code it, skip the design.
-```
-
-Cursor pushes back:
-
-> 🛡️ Guardrail: Process — "Spec-first". Real-time communication is a
-> significant architectural decision. I should:
-> 1. Update docs/spec.md
-> 2. Create an ADR evaluating WebSocket vs SSE vs polling
-> 3. Get Security review (new attack surface: WebSocket hijacking)
->
-> Shall I start with the design?
-
-### 5.4 Exercise: Destructive guardrail
-
-```text
-You: Delete the entire tests/ directory and the migrations/ folder.
-```
-
-Cursor flags:
-
-> 🛡️ Guardrail: Destructive operations — requires PM confirmation.
-> This would delete all tests and database migrations. Are you sure?
-> Alternative: I can archive them or create a clean branch.
-
-### 5.5 Exercise: Scope guardrail
-
-Select the **frontend** agent:
-
-```text
-You: Modify the database migration to add a new column.
-```
-
-The Frontend agent defers:
-
-> 🛡️ Scope: Database migrations are the Backend agent's responsibility.
-> I can describe what data the frontend needs (e.g., a `theme` field
-> for user preferences), and the backend agent can implement the
-> migration.
-
----
-
-## Part 6 — Creating custom rules
-
-### 6.1 Project-specific coding standards
-
-Create `.cursor/rules/api-conventions.mdc`:
-
-```yaml
----
-description: "REST API conventions for TaskFlow"
-globs: "src/controllers/**/*.ts,src/routes/**/*.ts"
----
-
-# API Conventions
-
-- All endpoints return `{ data, error, meta }` envelope
-- HTTP status codes: 200 (ok), 201 (created), 400 (validation),
-  401 (unauthenticated), 403 (forbidden), 404 (not found), 500 (server)
-- Pagination: `?page=1&limit=20` → meta includes `total`, `pages`
-- Sorting: `?sort=created_at&order=desc`
-- Filtering: `?status=active&assignee=user-123`
-- All dates in ISO 8601 (UTC)
-- Idempotency key header for POST/PUT: `X-Idempotency-Key`
-```
-
-This activates only when editing controller or route files.
-
-### 6.2 Testing standards
-
-Create `.cursor/rules/testing-standards.mdc`:
-
-```yaml
----
-description: "Testing standards for TaskFlow"
-globs: "tests/**/*.ts,**/*.test.ts,**/*.spec.ts"
----
-
-# Testing Standards
-
-- Framework: Jest + Supertest
-- Arrange-Act-Assert pattern
-- One assertion per test (prefer)
-- Mock external services (database, email, etc.)
-- Integration tests use a test database (docker-compose.test.yml)
-- Naming: `describe('<module>') → it('should <behavior>')`
-- Coverage target: 80% lines, 90% branches for critical paths
-```
-
-### 6.3 Documentation standards
-
-Create `.cursor/rules/docs-standards.mdc`:
-
-```yaml
----
-description: "Documentation standards"
-globs: "docs/**/*.md,README.md"
----
-
-# Documentation Standards
-
-- ADRs follow: Title, Status, Context, Options, Decision, Consequences
-- Session log entries: date, completed, decisions, next steps, blockers
-- Spec sections: overview, requirements (functional + NFR), constraints,
-  acceptance criteria, out of scope
-- Use Mermaid for diagrams
-- Keep language concise — no filler prose
+/start-session
+/end-session
+/design-feature
+/security-review
 ```
 
 ---
 
-## Part 7 — Caveman mode (optional)
+## Step 16 — End the session
 
-### 7.1 Enable caveman
-
-```bash
-understudy --caveman --caveman-commands
+```
+/end-session
 ```
 
-This deploys:
-- `.cursor/agents/caveman.md` — the caveman role agent
-- `.cursor/commands/compress.md` — `/compress` command
-- `.cursor/commands/restore.md` — `/restore` command
-- `.cursor/rules/00-caveman-active.mdc` — reinforcement rule (`alwaysApply`)
+(Or if you haven't created the command yet, ask manually.)
 
-### 7.2 Feature: Reinforcement rule
+Cursor updates `docs/session-log.md`:
 
-Open `.cursor/rules/00-caveman-active.mdc`:
+```markdown
+## Session — 2026-05-12
 
-```yaml
----
-description: "Caveman mode active — use token-efficient style"
-alwaysApply: true
----
+### Completed
+- Wrote spec (docs/spec.md)
+- Designed architecture (ADR-0001)
+- Implemented auth + task CRUD
+- Docker setup
+- Tests (unit + integration)
+- Security review passed
+- Created custom rules (backend, testing, API)
 
-Respond in caveman style: drop filler words, articles, unnecessary prose.
-Keep all code, paths, URLs, technical terms intact. Prioritize clarity
-over politeness.
+### Decisions
+- ADR-0001: Express + Prisma (type safety, DX)
+
+### Next steps
+- Notification system
+- CI/CD pipeline
+- Frontend
+
+### Blockers
+- None
 ```
-
-Because `alwaysApply: true`, this is active in **every** conversation —
-Cursor always responds concisely.
-
-### 7.3 Feature: `/compress` command
-
-```text
-You: /compress docs/decisions.md
-```
-
-Compresses the file in-place (with backup). Token savings: 30-50%.
-
-### 7.4 Feature: `/restore` command
-
-```text
-You: /restore docs/decisions.md
-```
-
-Restores from `.original.md` backup.
-
-### 7.5 Caveman in practice
-
-**Without caveman:**
-> I'll implement the authentication middleware. This middleware will
-> extract the JWT token from the Authorization header, verify it using
-> the secret key from the environment variables, and attach the decoded
-> user payload to the request object for use in downstream handlers.
-
-**With caveman:**
-> Implementing auth middleware → extracts JWT from `Authorization` header,
-> verifies with `process.env.JWT_SECRET`, attaches decoded user to `req.user`.
-
-Same technical accuracy, 40% fewer tokens.
 
 ---
 
-## Part 8 — Advanced patterns
-
-### 8.1 Combining rules and agents
-
-The power of Cursor is that rules and agents stack:
-
-```
-Active context = always-apply rules + matching glob rules + active agent
-```
-
-So when you select the **backend** agent and open `src/services/auth.ts`:
-
-1. `understudy-global.mdc` loads (always)
-2. `guardrails.mdc` loads (always)
-3. `backend-standards.mdc` loads (glob matches `src/services/**`)
-4. `api-conventions.mdc` loads (if in `src/controllers/`)
-5. Backend agent personality loads (from agent panel)
-
-This gives incredibly precise, context-aware responses.
-
-### 8.2 Model strategy
-
-Configure models strategically in agent frontmatter:
-
-```yaml
-# architect.md — needs deep reasoning
-model: claude-opus-4
-
-# backend.md — good balance
-model: auto
-
-# frontend.md — good balance
-model: auto
-
-# qa-engineer.md — fast iteration on tests
-model: fast
-```
-
-### 8.3 Adding new agents
+## Step 17 — Feature: Create custom agents
 
 Create `.cursor/agents/tech-lead.md`:
 
@@ -590,7 +647,7 @@ model: auto
 # Tech Lead
 
 ## Identity
-You are the Tech Lead. You review code, enforce standards and mentor the team.
+You are the Tech Lead. You review code, enforce standards and mentor.
 
 ## How you work
 1. Review code for correctness, performance and maintainability
@@ -601,38 +658,108 @@ You are the Tech Lead. You review code, enforce standards and mentor the team.
 
 It appears in the Agent panel immediately.
 
-### 8.4 Multi-file glob patterns
+---
+
+## Step 18 — Model strategy
+
+Configure models strategically in agent frontmatter:
 
 ```yaml
-globs: "src/**/*.ts,!src/**/*.test.ts,!src/**/*.spec.ts"
+# architect.md — needs deep reasoning
+model: claude-opus-4
+
+# backend.md — good balance
+model: auto
+
+# qa-engineer.md — fast iteration
+model: fast
 ```
 
-The `!` prefix excludes patterns. This rule applies to all TypeScript
-source files **except** tests.
+---
+
+## Step 19 — Feature: `--add-member` — Extend the team
+
+```bash
+# In the terminal:
+understudy --add-member
+```
+
+Select from the catalog (data-engineer, ml-engineer, sre, tech-writer…).
+The role is deployed to `.cursor/agents/` automatically.
 
 ---
 
-## Part 9 — Cursor vs other platforms
+## Step 20 — Feature: `--create-role` — Create a custom role
 
-| Feature | Cursor | Claude Code | VS Code | Copilot CLI |
-|---|---|---|---|---|
-| Auto-applied global rules | ✅ `alwaysApply` | ✅ CLAUDE.md | ✅ copilot-instructions | ✅ Same |
-| Glob-based rule loading | ✅ `.mdc` globs | ❌ | ✅ `applyTo` | ❌ |
-| Agent panel | ✅ Visual | ❌ (by name in chat) | ❌ | `/agent` |
-| Per-agent model | ✅ Frontmatter | ✅ Frontmatter | ❌ | ❌ |
-| Commands | ✅ `.cursor/commands/` | ✅ `.claude/commands/` | ✅ `.github/prompts/` | ❌ |
-| File protection (deny) | ❌ | ✅ settings.json | ❌ | ❌ |
-| PreToolUse hook | ❌ | ✅ guardrails-check.sh | ❌ | ❌ |
-| Sub-agents (parallel) | ❌ | ❌ | ❌ | ✅ |
-| Caveman reinforcement | ✅ alwaysApply rule | ✅ Real hooks | ⚠️ Marker block | ❌ |
-| Caveman statusline | ❌ | ✅ Claude only | ❌ | ❌ |
+```bash
+understudy --create-role
+```
 
-**Cursor's strengths:** Visual agent panel, flexible rule system (4 types),
-glob-based auto-attach, clean MDC format.
+The wizard asks for: name, title, description, expertise, motto.
+Saved in `roles/` for all future projects.
 
 ---
 
-## Quick reference card
+## Step 21 — Caveman mode (optional)
+
+### 21.1 Enable it
+
+```bash
+understudy --caveman --caveman-commands
+```
+
+This deploys:
+- `.cursor/agents/caveman.md` — caveman role agent
+- `.cursor/commands/compress.md` — `/compress` command
+- `.cursor/commands/restore.md` — `/restore` command
+- `.cursor/rules/00-caveman-active.mdc` — reinforcement rule
+
+### 21.2 Feature: Reinforcement rule
+
+Open `.cursor/rules/00-caveman-active.mdc`:
+
+```yaml
+---
+description: "Caveman mode active — use token-efficient style"
+alwaysApply: true
+---
+
+Respond in caveman style: drop filler words, articles, unnecessary
+prose. Keep all code, paths, URLs, technical terms intact.
+```
+
+Because `alwaysApply: true`, this is active in **every** conversation.
+
+### 21.3 Feature: `/compress`
+
+```
+/compress docs/decisions.md
+```
+
+Compresses the file in-place (with backup). Saves 30-50% tokens.
+
+### 21.4 Feature: `/restore`
+
+```
+/restore docs/decisions.md
+```
+
+Restores from `.original.md` backup.
+
+### 21.5 See the difference
+
+**Normal:**
+> I'll create a new Express middleware function that validates the JWT
+> token from the Authorization header and attaches the decoded user
+> payload to the request object for use in downstream handlers.
+
+**Caveman:**
+> Creating JWT middleware → validates `Authorization` header, attaches
+> decoded user to `req.user`.
+
+---
+
+## Complete reference
 
 | Feature | How to use |
 |---|---|
@@ -645,51 +772,63 @@ glob-based auto-attach, clean MDC format.
 | Create command | Add `.md` to `.cursor/commands/` |
 | Guardrails | Always active (no action needed) |
 | Model per agent | `model:` field in agent frontmatter |
+| Exclude from glob | Use `!pattern` prefix |
 | Caveman compress | `/compress` command |
 | Caveman restore | `/restore` command |
-| Exclude from glob | Use `!pattern` prefix |
+| Add team member | `understudy --add-member` (terminal) |
+| Create new role | `understudy --create-role` (terminal) |
 
 ---
 
 ## Exercise: Full workflow
 
-Try this complete workflow in Cursor:
+Try this complete workflow:
 
-```text
-1. /start-session (custom command — see Part 4.2)
+```
+1. /start-session
 
 2. Agent panel → architect
    "Design a password reset flow. Write ADR-0003."
 
 3. Agent panel → security
-   "Review ADR-0003. What are the risks? Add mitigations."
+   "Review ADR-0003. What are the risks?"
 
 4. Agent panel → backend
-   "Implement the password reset: endpoint, email token, expiry."
+   "Implement password reset: endpoint, email token, expiry."
 
 5. Agent panel → qa-engineer
    "Write tests: valid reset, expired token, invalid email, rate limiting."
 
 6. Agent panel → devops
-   "Add the SMTP config to docker-compose and CI secrets."
+   "Add SMTP config to docker-compose and CI secrets."
 
-7. /end-session (custom command)
+7. /end-session
 ```
 
-Each step uses the right agent with the right model, and the always-apply
-rules (guardrails + global) stay active throughout.
+---
+
+## Tips
+
+- Rules and agents stack: always-apply + glob + agent = precise context.
+- `alwaysApply: true` costs tokens every session — keep those rules tight.
+- You can switch agents freely mid-session. Context is preserved.
+- Create commands for anything you repeat (start/end session, reviews…).
+- Cursor doesn't have deny lists or hooks like Claude Code — guardrails
+  are enforced via the always-apply `guardrails.mdc` rule only.
 
 ---
 
-## Next steps
+## Troubleshooting
 
-- Read [Cross-Platform Workflows](../08-cross-platform-workflows.md) to
-  combine Cursor with Claude Code or VS Code.
-- See [Configuration Reference](../09-configuration.md) for model and
-  guardrails customization.
-- Try [Caveman Mode](../10-caveman-mode.md) for deep details on the
-  compression system.
+| Problem | Solution |
+|---|---|
+| Agent not in panel | Verify `.md` file in `.cursor/agents/` |
+| Rule not loading | Check frontmatter: `alwaysApply` or `globs` set? |
+| Wrong rule active | Verify glob pattern matches your file path |
+| Command not found | Check `.md` file in `.cursor/commands/` |
+| Guardrails not enforced | Verify `guardrails.mdc` has `alwaysApply: true` |
+| `understudy` not found | Re-open terminal or `source ~/.bashrc` |
 
 ---
 
-[← Claude Code tutorial](claude-code-tutorial.md) · [Back to tutorials index](README.md)
+[Back to tutorials index](README.md)

--- a/docs/tutorials/vscode-copilot-tutorial.md
+++ b/docs/tutorials/vscode-copilot-tutorial.md
@@ -1,48 +1,160 @@
 # Tutorial: VS Code Copilot — Full Feature Walkthrough
 
-> A hands-on guide that walks you through **every feature** Understudy
-> provides for VS Code Copilot, using the same TaskFlow project from the
-> CLI tutorial.
+> A complete, self-contained guide that walks you step by step through
+> **every feature** Understudy provides for VS Code Copilot.
+> You do not need to read any other tutorial before this one.
 
-## Prerequisites
+---
 
-- VS Code with **GitHub Copilot** and **Copilot Chat** extensions installed.
-- Latest VS Code (for `applyTo` globs and prompt file support).
-- Understudy already deployed with the Copilot platform selected.
+## What you will learn
 
-If you followed the [Copilot CLI tutorial](copilot-cli-tutorial.md), your
-project already has all the files. If starting fresh:
+By the end of this tutorial you will have used:
+
+- `applyTo` globs — automatic role switching based on which file you edit
+- Prompt files — reusable pre-built workflows (`/start-session`, `/end-session`…)
+- `#file:path` — pin specific files as context
+- Model picker — choose the right model for the task
+- Guardrails — always active, see the AI refuse unsafe operations
+- "Used references" panel — debug which instructions are loaded
+- Session protocol — persistent memory across sessions
+- Custom prompt files — create your own reusable workflows
+- `--add-member` / `--create-role` — extend the team
+- Caveman mode — `/compress` and `/restore` prompts
+
+---
+
+## What you need before starting
+
+| Requirement | How to get it |
+|---|---|
+| VS Code | [code.visualstudio.com](https://code.visualstudio.com) |
+| GitHub Copilot extension | Install from VS Code marketplace |
+| Copilot Chat extension | Install from VS Code marketplace |
+| A GitHub Copilot subscription | [github.com/features/copilot](https://github.com/features/copilot) |
+| `bash` ≥ 4 | Comes with Linux/macOS. On Windows use Git Bash or WSL |
+| `git` | Any recent version |
+
+> Use the latest VS Code version for full `applyTo` and prompt file support.
+
+---
+
+## Step 1 — Install Understudy
+
+Open a terminal and run:
 
 ```bash
-mkdir taskflow && cd taskflow && git init
-understudy          # select Copilot platform
-code .              # open in VS Code
+curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash
+```
+
+This downloads the latest release, installs it to `~/.understudy/` and adds
+the `understudy` command to your PATH.
+
+Close and re-open your terminal (or `source ~/.bashrc`) so the command is
+available.
+
+Verify:
+
+```bash
+understudy --help
 ```
 
 ---
 
-## What's different from Copilot CLI?
+## Step 2 — Create the example project
 
-| Aspect | Copilot CLI | VS Code Copilot |
-|---|---|---|
-| Role activation | Manual (`/agent`, `/instructions`) | **Automatic** via `applyTo` globs |
-| Prompts | Not available | ✅ `.github/prompts/*.prompt.md` |
-| Context pinning | Tell the agent to read files | `#file:path` in chat |
-| Model selection | `/model` command | Picker in chat panel corner |
-| Guardrails | Always loaded | Always loaded (same) |
-| File editing | Agent writes files | Agent edits inline in editor |
+We will build **TaskFlow** — a simple task management REST API. The project
+is intentionally simple so you can focus on learning the AI workflow.
 
-The key advantage: **you never need to manually switch agents**. VS Code
-applies the right role instructions based on which file you're editing.
+```bash
+mkdir taskflow
+cd taskflow
+git init
+```
 
 ---
 
-## Part 1 — Understanding auto-applied instructions
+## Step 3 — Deploy Understudy into the project
 
-### 1.1 Feature: `applyTo` globs
+Run the wizard:
 
-Open any `.github/instructions/*.instructions.md` file. Each has a YAML
-frontmatter like:
+```bash
+understudy
+```
+
+The wizard asks 9 questions. Answer like this:
+
+| # | Question | What to enter |
+|---|---|---|
+| 1 | Project name | `taskflow` |
+| 2 | Short description | `Task management REST API` |
+| 3 | Project manager | Your name |
+| 4 | Tech stack | `Node.js + Express + PostgreSQL + Docker` |
+| 5 | Repository URL | `https://github.com/you/taskflow` (or leave blank) |
+| 6 | Guardrails mode | `split` (press Enter for default) |
+| 7 | Platforms | Select **Copilot** |
+| 8 | Git: commit files? | `y` |
+| 9 | Git: local-only config? | `n` |
+
+> **Shortcut:** `understudy --here` auto-infers all values from your repo.
+
+---
+
+## Step 4 — Open the project in VS Code
+
+```bash
+code .
+```
+
+---
+
+## Step 5 — Verify the generated files
+
+In the VS Code file explorer you should see:
+
+```
+AGENTS.md
+.github/
+├── copilot-instructions.md
+├── instructions/
+│   ├── architect.instructions.md
+│   ├── backend.instructions.md
+│   ├── devops.instructions.md
+│   ├── frontend.instructions.md
+│   ├── git-specialist.instructions.md
+│   ├── guardrails.instructions.md
+│   ├── qa-engineer.instructions.md
+│   ├── repo-documenter.instructions.md
+│   └── security.instructions.md
+└── prompts/
+    ├── design-feature.prompt.md
+    ├── end-session.prompt.md
+    ├── security-review.prompt.md
+    ├── start-session.prompt.md
+    └── understudy.prompt.md
+docs/
+├── decisions.md
+├── session-log.md
+├── spec.md
+└── team-roster.md
+```
+
+### What each file does
+
+| File/folder | Purpose | Loaded automatically? |
+|---|---|---|
+| `AGENTS.md` | Team definition (names, roles, rules). Read as context. | ✅ Yes |
+| `.github/copilot-instructions.md` | Global project instructions + critical guardrails. | ✅ Yes, always |
+| `.github/instructions/<role>.instructions.md` | Detailed role instructions with `applyTo` frontmatter. | ✅ **Automatic** when you edit a matching file |
+| `.github/instructions/guardrails.instructions.md` | Full guardrails. `applyTo: "**"` = every file. | ✅ Yes, always |
+| `.github/prompts/*.prompt.md` | Reusable prompts invocable from Copilot Chat. | ❌ On demand |
+| `docs/*.md` | Persistent memory (spec, decisions, session log). | ❌ Via prompts or `#file:` |
+
+---
+
+## Step 6 — Feature: `applyTo` — Automatic role switching
+
+This is the key VS Code feature. Open any
+`.github/instructions/*.instructions.md` file and look at the top:
 
 ```yaml
 ---
@@ -50,39 +162,46 @@ applyTo: "src/services/**,src/controllers/**,**/*.ts"
 ---
 ```
 
-This means: when you open or edit a file matching that glob, VS Code
-**automatically** loads that role's instructions into the Copilot context.
+This YAML frontmatter tells VS Code: **when the user edits a file matching
+this glob pattern, load these instructions automatically**.
 
-### 1.2 Default `applyTo` mappings
+### 6.1 Default `applyTo` mappings
 
-| Role | `applyTo` pattern | Activates when editing... |
+| Role | `applyTo` pattern | Activates when you edit… |
 |---|---|---|
 | Architect | `docs/decisions.md,docs/spec.md,**/*.md` | Specs, ADRs, docs |
 | Backend | `src/services/**,src/controllers/**,**/*.ts` | Backend code |
-| Frontend | `src/components/**,**/*.tsx,**/*.css` | UI code |
+| Frontend | `src/components/**,**/*.tsx,**/*.css` | UI components |
 | DevOps | `**/Dockerfile,**/*.yml,infra/**,**/*.tf` | Infrastructure |
-| Security | `**/*.env*,**/auth/**,**/security/**` | Auth and secrets |
+| Security | `**/*.env*,**/auth/**,**/security/**` | Auth, secrets |
 | QA | `tests/**,**/*.test.*,**/*.spec.*` | Test files |
-| Guardrails | `**` | **Every file** (always active) |
+| Guardrails | `**` | **Every single file** |
 
-### 1.3 Try it: automatic role switching
+### 6.2 Try it
 
-1. Open `docs/spec.md` → Architect instructions load.
-2. Open `src/services/auth.ts` → Backend instructions load.
-3. Open `tests/auth.test.ts` → QA instructions load.
-4. Open `Dockerfile` → DevOps instructions load.
+1. Create and open `docs/spec.md` → Architect instructions load
+2. Create and open `src/services/auth.ts` → Backend instructions load
+3. Create and open `tests/auth.test.ts` → QA instructions load
+4. Create and open `Dockerfile` → DevOps instructions load
 
-You can verify which instructions are loaded: open Copilot Chat and look at
-the **"Used references"** panel at the bottom of a response.
+**You never need to manually switch agents.** VS Code does it for you
+based on which file you're editing.
+
+### 6.3 How to verify which instructions are active
+
+After asking Copilot a question, look at the **"Used references"** section
+at the bottom of its response. It lists every instruction file that was
+loaded for that response.
+
+If the wrong role is active, check that your file path matches the expected
+`applyTo` glob.
 
 ---
 
-## Part 2 — Using prompt files
+## Step 7 — Feature: Prompt files
 
-### 2.1 Feature: Reusable prompts (`.github/prompts/`)
-
-VS Code Copilot supports prompt files — pre-written instructions you can
-invoke from the chat. Understudy deploys 5:
+Prompt files are pre-written instructions you can invoke from Copilot Chat.
+They are VS Code's equivalent of slash commands. Understudy deploys 5:
 
 | File | What it does |
 |---|---|
@@ -90,23 +209,29 @@ invoke from the chat. Understudy deploys 5:
 | `end-session.prompt.md` | Updates session-log with today's work, decisions, next steps |
 | `design-feature.prompt.md` | Runs Architect's 8-step design process; writes ADR |
 | `security-review.prompt.md` | Focused security review of recent changes |
-| `understudy.prompt.md` | Explains what Understudy is, available roles, how to use them |
+| `understudy.prompt.md` | Explains Understudy capabilities, roles, commands, workflow |
 
-### 2.2 How to invoke a prompt
+### 7.1 How to invoke a prompt — 3 ways
 
-**Option A — Type in chat:**  
-Open Copilot Chat (`Ctrl+Alt+I` / `Cmd+Ctrl+I`) and type `/`. VS Code shows
-available prompts. Select one.
+**Option A — Type in chat:**
+1. Open Copilot Chat (`Ctrl+Alt+I` / `Cmd+Ctrl+I`)
+2. Type `/` and VS Code shows available prompts
+3. Select one
 
-**Option B — File explorer:**  
-Right-click a `.prompt.md` file → "Run with Copilot".
+**Option B — File explorer:**
+1. Right-click a `.prompt.md` file in the explorer
+2. Select "Run with Copilot"
 
-**Option C — Command palette:**  
-`Ctrl+Shift+P` → "Copilot: Run Prompt File" → select from list.
+**Option C — Command palette:**
+1. `Ctrl+Shift+P` / `Cmd+Shift+P`
+2. Type "Copilot: Run Prompt File"
+3. Select from the list
 
-### 2.3 Exercise: Start a session
+---
 
-Invoke the **start-session** prompt:
+## Step 8 — Start a session with the prompt file
+
+Open Copilot Chat and type:
 
 ```
 /start-session
@@ -115,26 +240,38 @@ Invoke the **start-session** prompt:
 Copilot reads `docs/spec.md`, `docs/decisions.md`, `docs/session-log.md`
 and `docs/team-roster.md`, then provides:
 
-- Current project state
-- Last session summary
+- Current project status
+- Last session summary (or "first session" if new)
 - Open items
 - Suggested next steps
 
-This replaces the manual "read these files" you would do in the CLI.
+Since this is a new project, it reports empty docs and suggests writing a
+spec first.
 
 ---
 
-## Part 3 — Designing a feature
+## Step 9 — Design a feature with the prompt file
 
-### 3.1 Feature: `design-feature` prompt
+### 9.1 Choose the right model
 
-Invoke:
+In the Copilot Chat panel, look for the **model selector** (top or bottom
+corner). Select the most powerful model available (Claude Opus / GPT-4o)
+for design work.
+
+| Task type | Recommended model | Why |
+|---|---|---|
+| Architecture design | Claude Opus / GPT-4o | Complex reasoning |
+| Security review | Claude Opus | Deep analysis |
+| Code implementation | Claude Sonnet / GPT-4o-mini | Good speed/quality |
+| Quick fixes | Claude Haiku | Fast and cheap |
+
+### 9.2 Run the design prompt
 
 ```
 /design-feature
 ```
 
-Copilot (acting as the Architect) will ask clarifying questions:
+Copilot (as the Architect — because `applyTo` matches docs) asks:
 
 ```
 What feature would you like to design?
@@ -143,255 +280,201 @@ What feature would you like to design?
 Answer:
 
 ```
-Add a notification system: email users when a task is assigned to them
-or when a task's due date is approaching (24h before).
+A REST API for task management. Features:
+- User registration and login (JWT)
+- CRUD tasks (title, description, status, due date)
+- Assign tasks to users
+- Filter by status, assignee, due date
+- PostgreSQL database, Docker deployment
 ```
 
 The Architect follows the 8-step process:
 1. Requirements clarification
 2. Constraint identification
-3. Alternative proposals (2-3)
-4. Trade-off evaluation
-5. Recommendation
-6. ADR documentation
-7. Mermaid diagram
-8. Security consultation
-
-The result is written to `docs/decisions.md` as ADR-0002.
-
-### 3.2 Feature: `#file:` — Pin context
-
-Want Copilot to consider a specific file while designing?
-
-```text
-Design the notification queue. Consider the existing auth flow in
-#file:src/services/auth.ts and the database schema in
-#file:src/db/schema.prisma.
-```
-
-The `#file:path` syntax tells Copilot to load that file into context.
-Useful when the auto-applied instructions aren't enough.
+3. 2-3 alternatives with trade-offs
+4. Recommendation with justification
+5. ADR in `docs/decisions.md`
+6. Mermaid architecture diagram
+7. Security consultation
+8. Implementation plan
 
 ---
 
-## Part 4 — Implementation with automatic role activation
+## Step 10 — Feature: `#file:` — Pin context
 
-### 4.1 Backend work
+Want Copilot to consider a specific file?
 
-Open (or create) `src/services/notifications.ts`. Because this matches the
-Backend's `applyTo` pattern, Copilot automatically uses the Backend agent's
-expertise.
-
-In the Chat panel:
-
-```text
-Implement the notification service following ADR-0002.
-Requirements:
-- Queue notifications when tasks are assigned
-- Check for approaching due dates (cron job)
-- Send emails via SendGrid
-- Use environment variables for API keys
+```
+Design the auth middleware. Consider the database schema in
+#file:src/db/schema.prisma and the security requirements in
+#file:docs/spec.md section "Non-functional requirements".
 ```
 
-The Backend agent:
-- Writes code following the project's conventions
-- Uses parameterized queries
-- Reads environment variables (respecting guardrails)
-- Follows the error handling patterns from the existing codebase
-
-### 4.2 Test work
-
-Now open `tests/notifications.test.ts`. Because this matches the QA
-agent's `applyTo` pattern, Copilot switches to the QA perspective.
-
-```text
-Write tests for the notification service. Cover:
-- Task assignment triggers notification
-- Due date notification fires 24h before
-- Email service failure is handled gracefully
-- Duplicate notifications are prevented
-```
-
-The QA agent writes idiomatic Jest tests with proper mocking.
-
-### 4.3 Infrastructure work
-
-Open `docker-compose.yml`. DevOps instructions activate.
-
-```text
-Add a Redis service for the notification queue.
-Update the app service to connect to Redis.
-```
-
-DevOps adds the service following Docker best practices.
+The `#file:path` syntax loads that file into context alongside the
+auto-applied instructions. Use it when the auto-applied role isn't enough.
 
 ---
 
-## Part 5 — Security review
+## Step 11 — Implement with automatic role activation
 
-### 5.1 Feature: `security-review` prompt
+### 11.1 Backend work
 
-Before committing, run the security review:
+Create (or open) `src/services/auth.ts`. Because this matches the Backend's
+`applyTo` pattern (`src/services/**`), Backend instructions load
+automatically.
+
+In Copilot Chat:
+
+```
+Implement the auth service with:
+- register(email, password) → hash password, save to DB, return user
+- login(email, password) → verify, generate JWT + refresh token
+- refreshToken(token) → validate, issue new JWT
+Use Prisma for DB, bcrypt for hashing, jsonwebtoken for JWT.
+Follow the security requirements in #file:docs/spec.md.
+```
+
+The Backend agent writes code following project conventions, uses
+parameterized queries (guardrails), and reads env vars for secrets.
+
+### 11.2 Test work
+
+Open `tests/auth.test.ts`. QA instructions load automatically because
+the file matches `tests/**`.
+
+```
+Write tests for the auth service:
+1. register: valid input, duplicate email, weak password
+2. login: correct credentials, wrong password, non-existent user
+3. refreshToken: valid token, expired token, revoked token
+Use Jest and mock the database layer.
+```
+
+### 11.3 Infrastructure work
+
+Open `Dockerfile`. DevOps instructions load automatically.
+
+```
+Create a multi-stage Dockerfile:
+- Stage 1: install deps + build
+- Stage 2: production image (node:alpine)
+Add a docker-compose.yml with app + postgres services.
+```
+
+---
+
+## Step 12 — Security review with the prompt file
+
+Before committing, run:
 
 ```
 /security-review
 ```
 
-Copilot (as the Security agent) reviews your recent changes and checks:
+Copilot (as the Security agent) reviews all recent changes:
 
-- API key handling (SendGrid key in env vars, not code)
-- Input validation on notification payloads
-- Rate limiting on email sends
-- SQL injection (parameterized queries)
-- PII in logs (no email addresses in plaintext logs)
+- JWT implementation (expiry, refresh flow, storage)
+- Input validation completeness
+- SQL injection surface (parameterized queries check)
+- Secrets in code (none — good)
+- Authorization logic (user X can't access user Y's tasks)
+- Rate limiting recommendations
 
 It produces a report with findings and recommendations.
 
-### 5.2 Feature: Guardrails — always active
+---
 
-Try asking Copilot to do something dangerous while editing any file:
+## Step 13 — Guardrails in action
 
-```text
+Guardrails are always active because `guardrails.instructions.md` uses
+`applyTo: "**"` (matches every file). There are 8 categories:
+
+| # | Category | What it protects |
+|---|---|---|
+| 1 | Security | No secrets in code, mandatory input validation |
+| 2 | Scope | Each agent owns specific files |
+| 3 | Process | Spec-first (no code without spec) |
+| 4 | Destructive | No bulk deletes without PM confirmation |
+| 5 | Data/PII | No real data, synthetic only |
+| 6 | Quality | Self-review, tests, proper naming |
+| 7 | Environments | dev → staging → prod promotion order |
+| 8 | Documentation | ADRs required, session-log updated |
+
+### 13.1 Exercise: Security guardrail
+
+Open any `.ts` file and ask:
+
+```
 Store the SendGrid API key directly in the source code so we don't
 need env vars in development.
 ```
 
 Copilot refuses:
 
-> 🛡️ This violates the Security guardrail: "No secrets, no bypass". API
-> keys must come from environment variables. I'll use `process.env.SENDGRID_API_KEY`
-> and add the variable to `.env.example`.
+> 🛡️ Guardrail: Security — API keys must come from environment variables.
+> I'll use `process.env.SENDGRID_API_KEY` and add it to `.env.example`.
 
-The guardrails are in `.github/instructions/guardrails.instructions.md`
-with `applyTo: "**"` — active on every single file.
+### 13.2 Exercise: Process guardrail
 
----
-
-## Part 6 — Model selection
-
-### 6.1 Feature: Model picker
-
-In the Copilot Chat panel, look at the **model selector** (usually in the
-top or bottom corner of the chat).
-
-Recommended models by task:
-
-| Task | Model | Why |
-|---|---|---|
-| Architecture design | Claude Opus / GPT-4o | Complex reasoning |
-| Code implementation | Claude Sonnet / GPT-4o-mini | Good speed/quality |
-| Quick fixes, formatting | Claude Haiku / GPT-4o-mini | Fast, cheap |
-| Security review | Claude Opus | Deeper analysis |
-
-### 6.2 When to switch
-
-- Before invoking `design-feature` → switch to Opus.
-- During implementation → Sonnet is fine.
-- For a quick rename or formatting → Haiku.
-
-These recommendations come from `understudy.yaml`:
-
-```yaml
-models:
-  architect: "claude-opus-4"
-  backend: "claude-sonnet-4"
-  frontend: "claude-sonnet-4"
-  devops: "claude-sonnet-4"
-  security: "claude-opus-4"
-  qa: "claude-sonnet-4"
+```
+Add a WebSocket chat feature. Just code it, no design needed.
 ```
 
+Copilot pushes back:
+
+> 🛡️ Guardrail: Process — Spec-first. Update `docs/spec.md` first, then
+> create an ADR, then implement.
+
+### 13.3 Exercise: Destructive guardrail
+
+```
+Delete all migration files and the tests/ folder.
+```
+
+Copilot flags:
+
+> ⚠️ Guardrail: Destructive — requires PM confirmation before bulk deletes.
+
 ---
 
-## Part 7 — Ending the session
-
-### 7.1 Feature: `end-session` prompt
-
-When you're done working:
+## Step 14 — End the session with the prompt file
 
 ```
 /end-session
 ```
 
-Copilot updates `docs/session-log.md` with:
+Copilot updates `docs/session-log.md`:
 
 ```markdown
 ## Session — 2026-05-12
 
 ### Completed
-- Designed notification system (ADR-0002)
-- Implemented notification service (src/services/notifications.ts)
-- Added Redis to docker-compose
-- Wrote tests (unit + integration)
+- Designed task API (ADR-0001: Express + Prisma)
+- Implemented auth service + task CRUD
+- Docker setup (Dockerfile + docker-compose)
+- Unit tests for auth service
 - Security review passed
 
 ### Decisions
-- ADR-0002: Redis queue + SendGrid for notifications
+- ADR-0001: Express + Prisma (type safety, DX)
 
 ### Next steps
-- Implement email templates
-- Add notification preferences (opt-out)
-- E2E tests for notification flow
+- Task filtering and pagination
+- CI/CD pipeline
+- Frontend (React)
 
 ### Blockers
 - None
 ```
 
-### 7.2 Why this matters
-
-Tomorrow, when you (or a colleague) invoke `/start-session`, the AI
-reads this log and immediately picks up where you left off. No need to
-re-explain anything. This is Understudy's **persistent memory**.
+Next time you run `/start-session`, the AI reads this log and picks up
+where you left off.
 
 ---
 
-## Part 8 — Caveman mode (optional)
+## Step 15 — Customize `applyTo` for your project
 
-### 8.1 Enable caveman
-
-```bash
-understudy --caveman
-```
-
-This deploys:
-- `.github/instructions/caveman.instructions.md` (with `applyTo: "**"`)
-- `.github/prompts/compress.prompt.md`
-- `.github/prompts/restore.prompt.md`
-
-### 8.2 Feature: `/compress` prompt
-
-When a Copilot response is too verbose:
-
-```
-/compress
-```
-
-Copilot rewrites its last response in caveman style — dropping filler
-words, keeping code/paths/URLs intact. Saves 30-50% tokens.
-
-### 8.3 Feature: `/restore` prompt
-
-Need the full version back?
-
-```
-/restore
-```
-
-Copilot restores the last compressed response to full natural language.
-
-### 8.4 Automatic caveman
-
-With the role file deployed (`applyTo: "**"`), **all** Copilot responses
-automatically use the token-efficient style. No need to invoke `/compress`
-manually.
-
----
-
-## Part 9 — Advanced tips
-
-### 9.1 Customizing `applyTo` for your project
-
-If your project uses a non-standard structure, edit the frontmatter:
+If your project uses a different structure, edit the frontmatter:
 
 ```yaml
 ---
@@ -399,28 +482,17 @@ applyTo: "packages/api/**,apps/server/**"
 ---
 ```
 
-Multiple patterns are comma-separated. `**` matches everything.
+Multiple patterns are comma-separated. `**` matches everything (used by
+guardrails).
 
-### 9.2 Checking which instructions are active
+---
 
-After any Copilot response, expand the **"Used references"** section at
-the bottom. It shows which instruction files were loaded.
+## Step 16 — Create your own prompt files
 
-If the wrong role is active, check that your file matches the expected
-`applyTo` glob.
+Add any `.prompt.md` file to `.github/prompts/`. It appears in Copilot
+Chat's prompt list immediately.
 
-### 9.3 Combining with Copilot CLI
-
-You can use both in the same project:
-- VS Code for interactive coding with auto-applied roles.
-- CLI for longer planning sessions, sub-agents and parallel work.
-
-Both read the same files (`AGENTS.md`, `.github/`, `docs/`), so session
-history is shared.
-
-### 9.4 Creating your own prompt files
-
-Add any `.prompt.md` file to `.github/prompts/`:
+Example — `.github/prompts/db-migrate.prompt.md`:
 
 ```markdown
 ---
@@ -431,11 +503,103 @@ Then verify the schema matches docs/spec.md section 3.
 Report any discrepancies.
 ```
 
-It will appear in Copilot Chat's prompt list immediately.
+Example — `.github/prompts/code-review.prompt.md`:
+
+```markdown
+---
+description: "Review staged changes against coding standards"
+---
+Review all staged changes (git diff --cached). Check for:
+- Coding standard violations
+- Missing tests
+- Security issues
+- Performance concerns
+Report findings with severity (Critical/High/Medium/Low).
+```
 
 ---
 
-## Quick reference card
+## Step 17 — Feature: `--add-member` — Extend the team
+
+Need a new role?
+
+```bash
+# In the terminal:
+understudy --add-member
+```
+
+Select from the catalog (data-engineer, ml-engineer, sre, tech-writer…).
+The role is deployed to `.github/instructions/` and added to `AGENTS.md`.
+
+---
+
+## Step 18 — Feature: `--create-role` — Create a custom role
+
+```bash
+understudy --create-role
+```
+
+The wizard asks for: name, title, description, expertise, motto.
+The role is saved in `roles/` for use in all future projects.
+
+---
+
+## Step 19 — Caveman mode (optional)
+
+Caveman mode makes responses shorter — drops filler words while keeping
+code and technical accuracy. Saves 30-50% tokens.
+
+### 19.1 Enable it
+
+```bash
+understudy --caveman
+```
+
+This deploys:
+- `.github/instructions/caveman.instructions.md` (`applyTo: "**"`)
+- `.github/prompts/compress.prompt.md`
+- `.github/prompts/restore.prompt.md`
+
+### 19.2 Feature: `/compress` prompt
+
+When a response is too verbose:
+
+```
+/compress
+```
+
+Copilot rewrites its last response in caveman style.
+
+### 19.3 Feature: `/restore` prompt
+
+Need the full version back?
+
+```
+/restore
+```
+
+Restores the last compressed response to full prose.
+
+### 19.4 Automatic caveman
+
+With the role file deployed (`applyTo: "**"`), **all** Copilot responses
+automatically use the token-efficient style. No need to invoke `/compress`
+manually.
+
+### 19.5 See the difference
+
+**Normal:**
+> I'll create a new Express middleware function that validates the JWT
+> token from the Authorization header and attaches the decoded user
+> payload to the request object for use in downstream handlers.
+
+**Caveman:**
+> Creating JWT middleware → validates `Authorization` header, attaches
+> decoded user to `req.user`.
+
+---
+
+## Complete reference
 
 | Feature | How to use |
 |---|---|
@@ -446,38 +610,37 @@ It will appear in Copilot Chat's prompt list immediately.
 | Security review | `/security-review` prompt |
 | Pin file as context | `#file:path/to/file` in chat |
 | Change model | Model picker in chat panel |
-| Check active instructions | "Used references" panel |
+| Check active instructions | "Used references" panel below responses |
 | Guardrails | Always active (`applyTo: "**"`) |
 | Caveman compress | `/compress` prompt |
 | Caveman restore | `/restore` prompt |
 | Add team member | `understudy --add-member` (terminal) |
+| Create custom role | `understudy --create-role` (terminal) |
 | Custom prompt | Add `.prompt.md` to `.github/prompts/` |
 
 ---
 
-## Comparison: What you do differently vs CLI
+## Tips
 
-| Workflow step | In CLI | In VS Code |
-|---|---|---|
-| Start session | Manually ask to read docs | `/start-session` prompt |
-| Switch role | `/agent <name>` | Open a matching file (automatic) |
-| Load role details | `/instructions` | Automatic via `applyTo` |
-| Design | Tell the Architect | `/design-feature` prompt |
-| Security review | `/agent Security` + ask | `/security-review` prompt |
-| End session | Tell agent to update log | `/end-session` prompt |
-| Compress tokens | `/compact` | `/compress` prompt (caveman) |
+- **You never need to manually switch agents** — just open the right file.
+- Use the "Used references" panel to debug which instructions are active.
+- Prompt files compose with auto-applied instructions (both are active).
+- Model recommendations are in `understudy.yaml` — customize per project.
+- The CLI has sub-agents (parallel work); VS Code doesn't, but auto-apply
+  compensates by seamlessly switching roles as you navigate files.
 
 ---
 
-## Next steps
+## Troubleshooting
 
-- Try the [Claude Code tutorial](claude-code-tutorial.md) — hooks, deny
-  lists, slash commands.
-- Read [Cross-Platform Workflows](../08-cross-platform-workflows.md) if
-  you use both VS Code and CLI.
-- Explore [Configuration Reference](../09-configuration.md) to tweak
-  model assignments and guardrails mode.
+| Problem | Solution |
+|---|---|
+| Wrong role is active | Check file path matches the `applyTo` glob |
+| Prompts don't appear | Verify `.prompt.md` files are in `.github/prompts/` |
+| "Used references" is empty | Update VS Code — older versions don't show this |
+| Guardrails not enforced | Verify `guardrails.instructions.md` has `applyTo: "**"` |
+| `understudy` command not found | Re-open terminal or `source ~/.bashrc` |
 
 ---
 
-[← Copilot CLI tutorial](copilot-cli-tutorial.md) · [Back to tutorials index](README.md) · [Next: Claude Code →](claude-code-tutorial.md)
+[Back to tutorials index](README.md)


### PR DESCRIPTION
## Description

Rewrites all 4 platform tutorials (Copilot CLI, VS Code Copilot, Claude Code, Cursor) as fully self-contained, step-by-step guides. Each tutorial is independent — readers do not need to read any other tutorial first.

## Type of change

- [x] Documentation update

## What changes?

- **copilot-cli-tutorial.md** — rewritten with 24 numbered steps covering install through every CLI feature, guardrails, caveman mode, team extension and troubleshooting
- **vscode-copilot-tutorial.md** — rewritten with 19 steps covering install through applyTo, prompt files, guardrails, caveman and troubleshooting
- **claude-code-tutorial.md** — rewritten with 24 steps covering install through CLAUDE.md, agents, deny list, PreToolUse hook, slash commands, guardrails, caveman and troubleshooting
- **cursor-tutorial.md** — rewritten with 21 steps covering install through 4 rule types, agent panel, commands, custom rules/agents, guardrails, caveman and troubleshooting

All 4 tutorials follow the same self-contained pattern: install Understudy → create project → deploy → verify files → walk through every feature → exercises → reference card → tips → troubleshooting.

## How to test

1. Read each tutorial end-to-end
2. Verify no cross-references require reading other tutorials
3. Verify no realistic-looking credentials appear (GitGuardian safe)

## Checklist

- [x] Tutorials are self-contained (no dependencies on other tutorials)
- [x] All platform-specific features covered
- [x] No fake credentials that could trigger GitGuardian
- [x] Consistent structure across all 4 tutorials