### PR TITLE
fix: replace ./wizard.sh with understudy in --help and header comment

### DIFF
--- a/wizard.sh
+++ b/wizard.sh
@@ -15,9 +15,12 @@
 #   - docs/ → spec, decisions, session log templates
 #
 #   Usage:
-#     ./wizard.sh                    → Interactive deployment
-#     ./wizard.sh --add-member       → Add a team member
-#     ./wizard.sh --help             → Help
+#     understudy                     → Interactive deployment
+#     understudy --here              → Deploy using inferred values
+#     understudy --here --yes        → Same as --here, skip confirmation
+#     understudy --add-member        → Add a team member
+#     understudy --create-role       → Create a new custom role
+#     understudy --help              → Show help
 #
 # ═══════════════════════════════════════════════════════════════
 
@@ -2053,12 +2056,13 @@ post_deploy() {
 show_help() {
     banner
     echo "  Usage:"
-    echo "    ./wizard.sh                  Interactive Understudy deployment"
-    echo "    ./wizard.sh --here           Deploy in current directory using inferred values"
-    echo "    ./wizard.sh --here --yes     Same as --here, skip confirmation prompt"
-    echo "    ./wizard.sh --add-member     Add a team member"
-    echo "    ./wizard.sh --create-role    Create a new custom role"
-    echo "    ./wizard.sh --help           Show this help"
+    echo "    understudy                   Interactive Understudy deployment"
+    echo "    understudy --here            Deploy in current directory using inferred values"
+    echo "    understudy --here --yes      Same as --here, skip confirmation prompt"
+    echo "    understudy --here -y         Short form of --yes"
+    echo "    understudy --add-member      Add a team member"
+    echo "    understudy --create-role     Create a new custom role"
+    echo "    understudy --help            Show this help"
     echo ""
 
     # Auto-list opt-in modules so adding modules/<name>/ surfaces in --help
@@ -2070,7 +2074,7 @@ show_help() {
             mflag="${MODULE_FLAGS_[$i]}"
             mname="${MODULE_NAMES[$i]}"
             desc="${MODULE_DESCS[$i]:-${MODULE_TITLES[$i]:-$mname}}"
-            printf "    ./wizard.sh %-13s %s\n" "$mflag" "$desc"
+            printf "    understudy %-14s %s\n" "$mflag" "$desc"
         done
         echo ""
     fi
@@ -2085,7 +2089,7 @@ show_help() {
         for j in "${!POSTINSTALL_FLAGS[@]}"; do
             pflag="${POSTINSTALL_FLAGS[$j]}"
             pdesc="${POSTINSTALL_DESCS[$j]:-(no description)}"
-            printf "    ./wizard.sh %-25s %s\n" "$pflag" "$pdesc"
+            printf "    understudy %-25s %s\n" "$pflag" "$pdesc"
         done
         echo ""
     fi


### PR DESCRIPTION
## Description

The `--help` output and the header comment in `wizard.sh` still reference `./wizard.sh` instead of the installed `understudy` command. This is confusing for users who installed via `install.sh` and use the `understudy` launcher.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] CI/CD

## What changes?

- **`show_help()`**: All usage lines now show `understudy` instead of `./wizard.sh`.
- **Header comment** (lines 17-23): Updated to list all 6 CLI options (`--here`, `--here --yes`, `--add-member`, `--create-role`, `--help`) — previously only listed 3.
- **Dynamic module/post-install `printf`s**: Also updated from `./wizard.sh` to `understudy`.
- **Added `-y` short form**: Explicitly shown as a shortcut for `--yes`.

## How to test

```bash
understudy --help
# Verify all lines show "understudy" instead of "./wizard.sh"
# Verify --here, --here --yes, --here -y, --add-member, --create-role, --help are listed
```

## Checklist

- [x] I have tested my changes locally
- [x] No new warnings or errors
- [x] Follows the project's coding style
