### PR TITLE
chore: release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-05-12
+
+### Fixed
+
+- `--help` output and header comment now show `understudy` instead of
+  `./wizard.sh` (#83).
+- Header comment updated to list all CLI options (`--here`, `--here --yes`,
+  `--add-member`, `--create-role`, `--help`).
+
 ## [0.9.0] - 2026-05-05
 
 ### Added


### PR DESCRIPTION
## Description

Release v0.9.1 — CHANGELOG update only.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] CI/CD

## What changes?

- Adds `[0.9.1] - 2026-05-12` entry to CHANGELOG.md with the `--help` fix from PR #83.

## How to test

- Review CHANGELOG.md formatting.

## Checklist

- [x] I have tested my changes locally
- [x] No new warnings or errors
- [x] Follows the project's coding style