### PR TITLE
feat: add PowerShell installer for Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- **PowerShell installer** (`install.ps1`): native Windows installer that
+  auto-detects Git for Windows `bash.exe`, downloads the release, extracts it,
+  creates a PowerShell launcher (`understudy.ps1`), and adds it to the user
+  PATH. Supports `-Version`, `-InstallDir`, `-NoPath` and `-Uninstall` flags.
+  Falls back gracefully if only WSL bash is available (validates bash actually
+  works before accepting it).
+
+### Changed
+
+- README and Quick Start docs updated with PowerShell installation instructions
+  alongside the existing bash one-liner.
+
 ## [0.9.1] - 2026-05-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -6,14 +6,13 @@
 
 ## Installation
 
-**One-liner** (Linux, macOS, Windows Git Bash / WSL):
+### Linux / macOS / Windows Git Bash / WSL
+
+**One-liner:**
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash
 ```
-
-This downloads the latest release, installs it to `~/.understudy/` and adds the
-`understudy` command to your PATH.
 
 **Specific version:**
 
@@ -21,7 +20,24 @@ This downloads the latest release, installs it to `~/.understudy/` and adds the
 curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash -s -- --version v1.0.0
 ```
 
-**Manual (clone):**
+### Windows (PowerShell)
+
+**One-liner:**
+
+```powershell
+irm https://raw.githubusercontent.com/erniker/understudy/main/install.ps1 | iex
+```
+
+**Specific version:**
+
+```powershell
+.\install.ps1 -Version v1.0.0
+```
+
+> Requires **Git for Windows** (provides `bash.exe`). The installer detects it
+> automatically and creates a PowerShell launcher that delegates to bash.
+
+### Manual (clone)
 
 ```bash
 git clone https://github.com/erniker/understudy.git
@@ -81,12 +97,23 @@ the full interactive wizard if you need to customize them.
 
 ### Install options
 
+**Bash (`install.sh`):**
+
 | Flag | Description |
 |---|---|
 | `--version <tag>` | Install a specific version (e.g. `v1.2.0`) |
 | `--dir <path>` | Custom install directory (default: `~/.understudy`) |
 | `--no-path` | Skip PATH setup |
 | `--uninstall` | Remove Understudy from the system |
+
+**PowerShell (`install.ps1`):**
+
+| Parameter | Description |
+|---|---|
+| `-Version <tag>` | Install a specific version (e.g. `v1.2.0`) |
+| `-InstallDir <path>` | Custom install directory (default: `~/.understudy`) |
+| `-NoPath` | Skip PATH setup |
+| `-Uninstall` | Remove Understudy from the system |
 
 ### Automatic update checks
 

--- a/docs/02-quick-start.md
+++ b/docs/02-quick-start.md
@@ -1,14 +1,27 @@
 # 2. Quick Start
 
-Works the same way on Linux, macOS and Windows (Git Bash or WSL).
+Works the same way on Linux, macOS and Windows (Git Bash, WSL, or PowerShell).
 
 ## Install
+
+### Linux / macOS / Git Bash / WSL
 
 **One-liner (recommended):**
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash
 ```
+
+### Windows (PowerShell)
+
+**One-liner:**
+
+```powershell
+irm https://raw.githubusercontent.com/erniker/understudy/main/install.ps1 | iex
+```
+
+> Requires **Git for Windows** (`bash.exe`). The installer auto-detects it and
+> creates a PowerShell-native launcher that delegates execution to bash.
 
 Then open a new terminal so the `understudy` command is available.
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,300 @@
+# ═══════════════════════════════════════════════════════════════
+# 🎭 Understudy — Windows Installer (PowerShell)
+# ═══════════════════════════════════════════════════════════════
+#
+# Usage (one-liner):
+#   irm https://raw.githubusercontent.com/erniker/understudy/main/install.ps1 | iex
+#
+# Or download and run with flags:
+#   .\install.ps1 -Version v1.0.0
+#
+# Parameters:
+#   -Version <tag>    Install a specific version (default: latest)
+#   -InstallDir <p>   Install to a custom directory (default: ~/.understudy)
+#   -NoPath           Skip PATH setup
+#   -Uninstall        Remove Understudy from the system
+#
+# Requires: Git for Windows (provides bash.exe)
+# ═══════════════════════════════════════════════════════════════
+
+[CmdletBinding()]
+param(
+    [string]$Version = "",
+    [string]$InstallDir = "",
+    [switch]$NoPath,
+    [switch]$Uninstall
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# ── Constants ─────────────────────────────────────────────────
+$Repo = "erniker/understudy"
+if (-not $InstallDir) { $InstallDir = Join-Path $HOME ".understudy" }
+$BinDir = Join-Path $HOME ".local" "bin"
+$BinName = "understudy.ps1"
+$GitHubApi = "https://api.github.com/repos/$Repo/releases/latest"
+$GitHubDownload = "https://github.com/$Repo/releases/download"
+
+# ── Helpers ───────────────────────────────────────────────────
+function Write-Info    { param([string]$Msg) Write-Host "  i  $Msg" -ForegroundColor Blue }
+function Write-Success { param([string]$Msg) Write-Host "  ✔  $Msg" -ForegroundColor Green }
+function Write-Warn    { param([string]$Msg) Write-Host "  ⚠  $Msg" -ForegroundColor Yellow }
+function Write-Err     { param([string]$Msg) Write-Host "  ✖  $Msg" -ForegroundColor Red }
+function Write-Step    { param([string]$Msg) Write-Host "`n  ▸ $Msg" -ForegroundColor Cyan }
+
+# ── Uninstall ─────────────────────────────────────────────────
+function Invoke-Uninstall {
+    Write-Step "Uninstalling Understudy"
+
+    if (Test-Path $InstallDir) {
+        Remove-Item -Recurse -Force $InstallDir
+        Write-Success "Removed $InstallDir"
+    } else {
+        Write-Warn "Install directory not found: $InstallDir"
+    }
+
+    $launcher = Join-Path $BinDir $BinName
+    if (Test-Path $launcher) {
+        Remove-Item -Force $launcher
+        Write-Success "Removed $launcher"
+    }
+
+    # Remove from user PATH if present
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    if ($userPath -and $userPath.Contains($BinDir)) {
+        $newPath = ($userPath.Split(';') | Where-Object { $_ -ne $BinDir }) -join ';'
+        [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+        Write-Success "Removed $BinDir from user PATH"
+    }
+
+    Write-Host ""
+    Write-Info "Understudy has been uninstalled."
+}
+
+if ($Uninstall) {
+    Invoke-Uninstall
+    exit 0
+}
+
+# ── Dependency check ──────────────────────────────────────────
+$script:BashPath = ""
+
+function Test-Dependencies {
+    Write-Step "Checking dependencies"
+
+    # Prefer Git for Windows bash over WSL bash
+    $gitCmd = Get-Command git -ErrorAction SilentlyContinue
+    if ($gitCmd) {
+        $gitDir = Split-Path (Split-Path $gitCmd.Source)
+        $gitBash = Join-Path $gitDir "bin" "bash.exe"
+        if (Test-Path $gitBash) {
+            $script:BashPath = $gitBash
+        }
+    }
+
+    # Fallback: common Git for Windows locations
+    if (-not $script:BashPath) {
+        $candidates = @(
+            "C:\Program Files\Git\bin\bash.exe",
+            "C:\Program Files (x86)\Git\bin\bash.exe",
+            "$env:LOCALAPPDATA\Programs\Git\bin\bash.exe"
+        )
+        foreach ($c in $candidates) {
+            if (Test-Path $c) { $script:BashPath = $c; break }
+        }
+    }
+
+    # Last resort: any bash in PATH (may be WSL — we test it)
+    if (-not $script:BashPath) {
+        $bash = Get-Command bash -ErrorAction SilentlyContinue
+        if ($bash) { $script:BashPath = $bash.Source }
+    }
+
+    if (-not $script:BashPath) {
+        Write-Err "bash.exe not found."
+        Write-Err "Understudy requires Git for Windows (includes bash)."
+        Write-Err "Download from: https://git-scm.com/download/win"
+        exit 1
+    }
+
+    # Verify it actually works (WSL bash fails if no distro installed)
+    try {
+        $testOut = & $script:BashPath -c "echo ok" 2>&1
+        if ($testOut -ne "ok") { throw "unexpected output" }
+    } catch {
+        Write-Err "bash at '$script:BashPath' is not functional (WSL without a distro?)."
+        Write-Err "Install Git for Windows: https://git-scm.com/download/win"
+        exit 1
+    }
+
+    Write-Success "bash found: $script:BashPath"
+
+    # Verify we can reach GitHub
+    try {
+        $null = Invoke-RestMethod -Uri "https://github.com" -Method Head -TimeoutSec 5 -ErrorAction Stop
+    } catch {
+        Write-Err "Cannot reach github.com. Check your internet connection."
+        exit 1
+    }
+    Write-Success "Network connectivity OK"
+}
+
+# ── Resolve version ───────────────────────────────────────────
+function Resolve-Version {
+    if ($Version) {
+        Write-Info "Version requested: $Version"
+        return $Version
+    }
+
+    Write-Info "Fetching latest version from GitHub..."
+    try {
+        $release = Invoke-RestMethod -Uri $GitHubApi -Headers @{ Accept = "application/vnd.github+json" }
+        $resolved = $release.tag_name
+    } catch {
+        Write-Err "Could not determine the latest version."
+        Write-Err "Check your internet connection or specify -Version <tag>."
+        exit 1
+    }
+
+    if (-not $resolved) {
+        Write-Err "GitHub API returned no tag_name."
+        exit 1
+    }
+
+    Write-Info "Latest version: $resolved"
+    return $resolved
+}
+
+# ── Download and extract ──────────────────────────────────────
+function Install-Understudy {
+    param([string]$Ver)
+
+    $archive = "understudy-${Ver}.tar.gz"
+    $url = "$GitHubDownload/$Ver/$archive"
+    $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) "understudy-install-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+    $null = New-Item -ItemType Directory -Path $tmpDir -Force
+
+    Write-Step "Downloading $archive"
+    Write-Info "From: $url"
+
+    try {
+        $archivePath = Join-Path $tmpDir $archive
+        Invoke-WebRequest -Uri $url -OutFile $archivePath -UseBasicParsing
+    } catch {
+        Write-Err "Download failed. Is the version tag correct? ($Ver)"
+        Remove-Item -Recurse -Force $tmpDir -ErrorAction SilentlyContinue
+        exit 1
+    }
+    Write-Success "Downloaded"
+
+    Write-Step "Installing to $InstallDir"
+
+    # Remove old installation if present
+    if (Test-Path $InstallDir) {
+        Write-Warn "Existing installation found — replacing it."
+        Remove-Item -Recurse -Force $InstallDir
+    }
+
+    $null = New-Item -ItemType Directory -Path $InstallDir -Force
+
+    # Extract .tar.gz — use tar (ships with Windows 10+)
+    $tar = Get-Command tar -ErrorAction SilentlyContinue
+    if ($tar) {
+        & tar -xzf $archivePath -C $InstallDir --strip-components=0
+    } else {
+        # Fallback: use bash's tar
+        & bash -c "tar -xzf '$($archivePath -replace '\\','/')' -C '$($InstallDir -replace '\\','/')' --strip-components=0"
+    }
+
+    Remove-Item -Recurse -Force $tmpDir -ErrorAction SilentlyContinue
+    Write-Success "Files installed to $InstallDir"
+}
+
+# ── Create launcher ───────────────────────────────────────────
+function New-Launcher {
+    Write-Step "Creating launcher: $BinDir\$BinName"
+
+    $null = New-Item -ItemType Directory -Path $BinDir -Force
+
+    $launcherContent = @"
+#!/usr/bin/env pwsh
+# Understudy launcher (Windows) — managed by install.ps1, do not edit.
+`$wizardPath = Join-Path `"$InstallDir`" "wizard.sh"
+`$bashExe = "$($script:BashPath -replace '\\', '\\')"
+& `$bashExe `$wizardPath @args
+"@
+
+    $launcherPath = Join-Path $BinDir $BinName
+    Set-Content -Path $launcherPath -Value $launcherContent -Encoding UTF8
+    Write-Success "Launcher created"
+}
+
+# ── PATH setup ────────────────────────────────────────────────
+function Set-UserPath {
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+
+    if ($userPath -and $userPath.Contains($BinDir)) {
+        Write-Info "$BinDir is already in PATH."
+        return
+    }
+
+    Write-Step "Adding $BinDir to user PATH"
+
+    if ($userPath) {
+        $newPath = "$BinDir;$userPath"
+    } else {
+        $newPath = $BinDir
+    }
+
+    [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+    Write-Success "Added to user PATH (persistent)"
+
+    # Also update current session
+    $env:Path = "$BinDir;$env:Path"
+    Write-Info "PATH updated for this session too."
+}
+
+# ── Post-install summary ──────────────────────────────────────
+function Show-PostInstall {
+    param([string]$Ver)
+
+    Write-Host ""
+    Write-Host "  ╔══════════════════════════════════════════╗" -ForegroundColor Green
+    Write-Host "  ║  🎭  Understudy $Ver installed!         ║" -ForegroundColor Green
+    Write-Host "  ╚══════════════════════════════════════════╝" -ForegroundColor Green
+    Write-Host ""
+    Write-Step "Quick start"
+    Write-Host ""
+    Write-Info "Deploy Understudy in any project:"
+    Write-Host ""
+    Write-Host "      cd C:\path\to\your\project" -ForegroundColor Cyan
+    Write-Host "      understudy" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Info "Add a team member:"
+    Write-Host "      understudy --add-member" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Info "Docs: https://github.com/$Repo#readme"
+    Write-Host ""
+
+    if (-not (Get-Command understudy -ErrorAction SilentlyContinue)) {
+        Write-Warn "Open a new PowerShell window for PATH changes to take effect."
+    }
+}
+
+# ── Main ──────────────────────────────────────────────────────
+Write-Host ""
+Write-Host "  🎭 Understudy Installer (Windows)" -ForegroundColor White
+Write-Host ""
+
+Test-Dependencies
+$Version = Resolve-Version
+
+Install-Understudy -Ver $Version
+New-Launcher
+
+if (-not $NoPath) {
+    Set-UserPath
+}
+
+Show-PostInstall -Ver $Version


### PR DESCRIPTION
## Description

Add a native PowerShell installer (`install.ps1`) so Windows users can install Understudy directly from PowerShell without needing to use Git Bash or WSL manually.

The installer auto-detects `bash.exe` from Git for Windows, validates it works (rejects broken WSL setups), downloads the release tarball, extracts it, creates a PowerShell-native launcher, and persists PATH changes to the Windows user environment.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation only
- [ ] Refactor

## What changes?

1. **New file: `install.ps1`** — Full PowerShell installer with:
   - Smart bash detection (Git for Windows > fallback candidates > PATH > validation)
   - Download + extract via `Invoke-WebRequest` + `tar`
   - Launcher creation (`understudy.ps1`) that delegates to `bash wizard.sh`
   - Persistent PATH setup via Windows registry (`[Environment]::SetEnvironmentVariable`)
   - Clean uninstall (`-Uninstall` flag)
2. **`README.md`** — Added PowerShell install section alongside existing bash one-liner; expanded install options table with PS parameters.
3. **`docs/02-quick-start.md`** — Added PowerShell one-liner and requirements note.
4. **`CHANGELOG.md`** — Documented the feature under `[Unreleased]`.

## How to test

```powershell
# Full end-to-end (downloads from GitHub releases)
.\install.ps1 -Version v0.9.1

# Verify it works
understudy --help

# Clean up
.\install.ps1 -Uninstall
```

Tested on Windows 11 with Git for Windows (`bash.exe` at `AppData\Local\Programs\Git\bin\bash.exe`).

## Checklist

- [x] Code follows existing style and conventions
- [x] Self-reviewed the diff
- [x] Documentation updated (README, Quick Start, CHANGELOG)
- [x] No breaking changes to existing install.sh workflow
- [x] Tested locally on Windows PowerShell
