### PR TITLE
chore(release): v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-05-13
+
 ### Added
 
 - **PowerShell installer** (`install.ps1`): native Windows installer that


### PR DESCRIPTION
## Description

Release v0.9.2 — stamps CHANGELOG with version number and date.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation only
- [x] Refactor

## What changes?

- CHANGELOG.md: moved Unreleased content under `[0.9.2] - 2026-05-13` heading.

## How to test

Verify CHANGELOG has correct heading and date.

## Checklist

- [x] Code follows existing style and conventions
- [x] Self-reviewed the diff
- [x] Documentation updated (README, Quick Start, CHANGELOG)
- [x] No breaking changes to existing install.sh workflow
- [x] Tested locally on Windows PowerShell
