### PR TITLE
docs: add install.ps1 references across all documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.9.5] - 2026-05-13
+
+### Changed
+
+- Document `install.ps1` (PowerShell installer) across all docs: tutorials,
+  platform guides, troubleshooting, contributing guide, and tutorials README.
+
 ## [0.9.4] - 2026-05-13
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,8 +38,9 @@ git fetch upstream
 git rebase upstream/main
 ```
 
-There are no build dependencies. The wizard requires **bash ≥ 3.2** (compatible with macOS, Linux, and Windows WSL).
+There are no build dependencies. The wizard requires **bash ≥ 3.2** (compatible with macOS, Linux, and Windows WSL / Git Bash).
 To contribute: clone the repo, then run the wizard with `./wizard.sh` or install globally with `./install.sh`.
+On Windows, you can also install with `install.ps1` (PowerShell) — it auto-detects Git for Windows `bash.exe`.
 
 ---
 

--- a/docs/11-troubleshooting.md
+++ b/docs/11-troubleshooting.md
@@ -80,10 +80,21 @@ If you prefer to update manually, re-run the installer:
 curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash
 ```
 
+On Windows (PowerShell):
+
+```powershell
+irm https://raw.githubusercontent.com/erniker/understudy/main/install.ps1 | iex
+```
+
 To pin a specific version:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash -s -- --version v1.2.0
+```
+
+```powershell
+# PowerShell
+.\install.ps1 -Version v1.2.0
 ```
 
 To disable the automatic check (CI, offline environments):
@@ -96,6 +107,11 @@ To uninstall:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash -s -- --uninstall
+```
+
+```powershell
+# PowerShell
+.\install.ps1 -Uninstall
 ```
 
 ## Existing project — will the wizard overwrite my code?
@@ -151,15 +167,29 @@ The order does not matter. Module flags (`--caveman`, `--caveman-hooks`,
 
 ## Windows: the wizard fails or shows garbled output
 
-Understudy requires a **bash-compatible shell**. On Windows, use one of:
+The recommended way to install on Windows is the **PowerShell installer**,
+which auto-detects Git for Windows and handles everything:
+
+```powershell
+irm https://raw.githubusercontent.com/erniker/understudy/main/install.ps1 | iex
+```
+
+After installation, the `understudy` command works from **any shell**
+(PowerShell, Git Bash, cmd.exe).
+
+### Running `wizard.sh` directly (advanced)
+
+If you prefer to run the wizard manually (e.g. from a git clone), you need
+a **bash-compatible shell**. On Windows, use one of:
 
 - **Git Bash** (installed with Git for Windows) — recommended
 - **WSL** (Windows Subsystem for Linux)
 - **MSYS2** or **Cygwin**
 
-PowerShell and `cmd.exe` are **not supported** for running the wizard
-directly. However, once deployed, the AI tools (Copilot, Claude, Cursor)
-work normally regardless of your shell.
+PowerShell and `cmd.exe` cannot run `wizard.sh` directly — this is why
+the PowerShell installer (`install.ps1`) is recommended. Once deployed,
+the AI tools (Copilot, Claude, Cursor) work normally regardless of
+your shell.
 
 ## `understudy-compress` says "python3 not found"
 

--- a/docs/platforms/claude-code.md
+++ b/docs/platforms/claude-code.md
@@ -15,6 +15,12 @@ Install Understudy first:
 curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash
 ```
 
+On Windows (PowerShell):
+
+```powershell
+irm https://raw.githubusercontent.com/erniker/understudy/main/install.ps1 | iex
+```
+
 Then open a new terminal so the `understudy` command is available.
 
 Deploy Understudy with Claude Code selected:

--- a/docs/platforms/copilot-cli.md
+++ b/docs/platforms/copilot-cli.md
@@ -17,6 +17,12 @@ Install Understudy first:
 curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash
 ```
 
+On Windows (PowerShell):
+
+```powershell
+irm https://raw.githubusercontent.com/erniker/understudy/main/install.ps1 | iex
+```
+
 Then open a new terminal so the `understudy` command is available.
 
 If you prefer a manual clone instead of the installed command, you need

--- a/docs/platforms/cursor.md
+++ b/docs/platforms/cursor.md
@@ -15,6 +15,12 @@ Install Understudy first:
 curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash
 ```
 
+On Windows (PowerShell):
+
+```powershell
+irm https://raw.githubusercontent.com/erniker/understudy/main/install.ps1 | iex
+```
+
 Then open a new terminal so the `understudy` command is available.
 
 Deploy Understudy with Cursor selected:

--- a/docs/platforms/vscode-copilot.md
+++ b/docs/platforms/vscode-copilot.md
@@ -17,6 +17,12 @@ Install Understudy first:
 curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash
 ```
 
+On Windows (PowerShell):
+
+```powershell
+irm https://raw.githubusercontent.com/erniker/understudy/main/install.ps1 | iex
+```
+
 Then open a new terminal so the `understudy` command is available.
 
 Deploy Understudy:

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -33,6 +33,6 @@ flows differently across platforms:
 
 ## Prerequisites
 
-- Understudy installed (`curl -fsSL ... | bash` or manual clone)
+- Understudy installed (`curl -fsSL ... | bash`, or `irm ... | iex` on Windows PowerShell, or manual clone)
 - The AI tool for your chosen platform installed and configured
-- A terminal with `bash ≥ 4` (for the wizard)
+- A terminal with `bash ≥ 4` (for the wizard; on Windows, Git for Windows provides it — the PowerShell installer sets this up automatically)

--- a/docs/tutorials/claude-code-tutorial.md
+++ b/docs/tutorials/claude-code-tutorial.md
@@ -37,11 +37,22 @@ By the end of this tutorial you will have used:
 
 ## Step 1 — Install Understudy
 
+### Linux / macOS / Git Bash / WSL
+
 Open a terminal and run:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash
 ```
+
+### Windows (PowerShell)
+
+```powershell
+irm https://raw.githubusercontent.com/erniker/understudy/main/install.ps1 | iex
+```
+
+> Requires **Git for Windows** (provides `bash.exe`). The installer detects it
+> automatically and creates a PowerShell launcher that delegates to bash.
 
 This downloads the latest release, installs it to `~/.understudy/` and adds
 the `understudy` command to your PATH.

--- a/docs/tutorials/copilot-cli-tutorial.md
+++ b/docs/tutorials/copilot-cli-tutorial.md
@@ -37,11 +37,22 @@ By the end of this tutorial you will have used:
 
 ## Step 1 — Install Understudy
 
+### Linux / macOS / Git Bash / WSL
+
 Open a terminal and run:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash
 ```
+
+### Windows (PowerShell)
+
+```powershell
+irm https://raw.githubusercontent.com/erniker/understudy/main/install.ps1 | iex
+```
+
+> Requires **Git for Windows** (provides `bash.exe`). The installer detects it
+> automatically and creates a PowerShell launcher that delegates to bash.
 
 This downloads the latest release, installs it to `~/.understudy/` and adds
 the `understudy` command to your PATH.

--- a/docs/tutorials/cursor-tutorial.md
+++ b/docs/tutorials/cursor-tutorial.md
@@ -36,11 +36,22 @@ By the end of this tutorial you will have used:
 
 ## Step 1 — Install Understudy
 
+### Linux / macOS / Git Bash / WSL
+
 Open a terminal and run:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash
 ```
+
+### Windows (PowerShell)
+
+```powershell
+irm https://raw.githubusercontent.com/erniker/understudy/main/install.ps1 | iex
+```
+
+> Requires **Git for Windows** (provides `bash.exe`). The installer detects it
+> automatically and creates a PowerShell launcher that delegates to bash.
 
 This downloads the latest release, installs it to `~/.understudy/` and adds
 the `understudy` command to your PATH.

--- a/docs/tutorials/vscode-copilot-tutorial.md
+++ b/docs/tutorials/vscode-copilot-tutorial.md
@@ -40,11 +40,22 @@ By the end of this tutorial you will have used:
 
 ## Step 1 — Install Understudy
 
+### Linux / macOS / Git Bash / WSL
+
 Open a terminal and run:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/erniker/understudy/main/install.sh | bash
 ```
+
+### Windows (PowerShell)
+
+```powershell
+irm https://raw.githubusercontent.com/erniker/understudy/main/install.ps1 | iex
+```
+
+> Requires **Git for Windows** (provides `bash.exe`). The installer detects it
+> automatically and creates a PowerShell launcher that delegates to bash.
 
 This downloads the latest release, installs it to `~/.understudy/` and adds
 the `understudy` command to your PATH.


### PR DESCRIPTION
## Description

Release v0.9.5 — document `install.ps1` (PowerShell installer) across all docs.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation only
- [ ] Refactor

## What changes?

Add PowerShell installer references to 12 documentation files:

- **4 tutorials** (vscode-copilot, cursor, claude-code, copilot-cli): Step 1 now shows both bash and PowerShell install options.
- **4 platform guides** (vscode-copilot, cursor, claude-code, copilot-cli): Setup sections include PowerShell one-liner.
- **tutorials/README.md**: Prerequisites mention PowerShell install for Windows.
- **11-troubleshooting.md**: Windows section now recommends `install.ps1` first, with manual `wizard.sh` instructions as advanced fallback. Update/uninstall section includes PowerShell equivalents.
- **CONTRIBUTING.md**: Getting started mentions `install.ps1` for Windows contributors.
- **CHANGELOG.md**: v0.9.5 entry.

## How to test

Open any tutorial or platform guide and verify the PowerShell install option appears alongside the bash one-liner.

## Checklist

- [x] Code follows existing style and conventions
- [x] Self-reviewed the diff
- [x] Documentation updated (README, Quick Start, CHANGELOG)
- [x] No breaking changes to existing install.sh workflow
- [x] Tested locally on Windows PowerShell
