### PR TITLE
feat: add GitHub Pages with MkDocs Material

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,49 @@
+name: Deploy docs to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install -r docs/requirements.txt
+
+      - name: Build site
+        run: mkdocs build --strict
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,20 @@
+# 🎭 Understudy
+
+> A system that configures specialized AI agents in any project.
+> One assistant, multiple roles: Architect, Backend, Frontend, DevOps, Security, QA.
+> Compatible with **GitHub Copilot CLI**, **VS Code**, **Claude Code** and **Cursor**.
+
+## Getting Started
+
+- New here? Start with the [Introduction](01-introduction.md) then follow the [Quick Start](02-quick-start.md).
+- Looking for a specific platform? Check the [Platform Comparison](03-platform-comparison.md) or jump to a platform guide.
+- Want a hands-on walkthrough? Try a [Tutorial](tutorials/README.md).
+
+## Platforms Supported
+
+| Platform | Guide |
+|----------|-------|
+| GitHub Copilot CLI | [Docs](platforms/copilot-cli.md) · [Tutorial](tutorials/copilot-cli-tutorial.md) |
+| VS Code Copilot | [Docs](platforms/vscode-copilot.md) · [Tutorial](tutorials/vscode-copilot-tutorial.md) |
+| Claude Code | [Docs](platforms/claude-code.md) · [Tutorial](tutorials/claude-code-tutorial.md) |
+| Cursor | [Docs](platforms/cursor.md) · [Tutorial](tutorials/cursor-tutorial.md) |

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs-material==9.6.14
+mkdocs>=1.6

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,62 @@
+site_name: Understudy
+site_description: Multi-platform AI coding assistant orchestration framework
+site_url: https://erniker.github.io/understudy/
+repo_url: https://github.com/erniker/understudy
+repo_name: understudy
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.highlight
+    - content.code.copy
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Introduction: 01-introduction.md
+  - Quick Start: 02-quick-start.md
+  - Platform Comparison: 03-platform-comparison.md
+  - Guardrails: 04-guardrails.md
+  - Roles & Workflow: 05-roles-and-workflow.md
+  - Cross-Platform Workflows: 08-cross-platform-workflows.md
+  - Configuration: 09-configuration.md
+  - Caveman Mode: 10-caveman-mode.md
+  - Troubleshooting: 11-troubleshooting.md
+  - Platforms:
+      - GitHub Copilot CLI: platforms/copilot-cli.md
+      - VS Code Copilot: platforms/vscode-copilot.md
+      - Claude Code: platforms/claude-code.md
+      - Cursor: platforms/cursor.md
+  - Tutorials:
+      - Overview: tutorials/README.md
+      - GitHub Copilot CLI: tutorials/copilot-cli-tutorial.md
+      - VS Code Copilot: tutorials/vscode-copilot-tutorial.md
+      - Claude Code: tutorials/claude-code-tutorial.md
+      - Cursor: tutorials/cursor-tutorial.md


### PR DESCRIPTION
## Description

Adds GitHub Pages deployment using MkDocs Material theme so the docs/ folder is published as a static site.

## Type of change

- [x] Documentation update

## What changes?

- **mkdocs.yml** — Site config with Material theme, full navigation, and markdown extensions
- **.github/workflows/docs.yml** — GitHub Actions workflow to auto-deploy to Pages on push to main
- **docs/index.md** — Site homepage with links to all docs and tutorials
- **docs/requirements.txt** — Python build dependencies (mkdocs-material)

## How to test

1. Install deps: \\\pip install -r docs/requirements.txt\\\
2. Run locally: \\\mkdocs serve\\\
3. Open http://localhost:8000 and verify navigation and pages render correctly

## Checklist

- [x] Docs updated
- [x] No breaking changes
- [x] CI passes