### PR TITLE
feat(wizard): add clickable file:// link to Cursor global setup instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- `understudy --global`'s one-time Cursor setup instructions now include a
+  clickable `file://` link to the generated paste-block file, in addition to
+  the plain path — one less step to get from the terminal to the file on
+  disk (Windows drive letters are uppercased to match the OS convention).
+
 ## [1.1.0] - 2026-07-13
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -417,7 +417,6 @@ tests/
 │   │   ├── partial.yaml                  # Only some keys
 │   │   └── empty.yaml                    # Empty file (default fallback)
 │   ├── fake-node-project/                # React + Node.js project structure
-│   ├── fake-dotnet-project/              # .csproj project structure
 │   ├── fake-python-project/              # requirements.txt project
 │   └── fake-monorepo/                    # React + Node + Terraform + Docker
 ├── unit/

--- a/tests/unit/global_paths.bats
+++ b/tests/unit/global_paths.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 # Tests for global-mode path resolution helpers in wizard.sh:
-# os_family, global_claude_dir, global_state_dir, detect_vscode_user_dirs.
-# Covers Linux/macOS/Windows detection and VS Code stable/Insiders lookup.
+# os_family, global_claude_dir, global_state_dir, detect_vscode_user_dirs,
+# path_to_file_uri. Covers Linux/macOS/Windows detection and VS Code
+# stable/Insiders lookup.
 
 load "../lib/helpers"
 
@@ -107,4 +108,42 @@ teardown() { teardown_tmp; }
   run normalize_path "${TEST_TMP}/AppData/Roaming"
   local expected_appdata="$output"
   [ "$expected_appdata" = "${TEST_TMP}/AppData/Roaming" ]
+}
+
+# ── path_to_file_uri ───────────────────────────────────────────────────────────
+
+@test "path_to_file_uri converts a git-bash mount path to an uppercase-drive file URI on Windows" {
+  uname() { echo "MINGW64_NT-10.0"; }
+  run path_to_file_uri "/c/Users/dev/.understudy-global/cursor-user-rules.md"
+  [ "$output" = "file:///C:/Users/dev/.understudy-global/cursor-user-rules.md" ]
+}
+
+@test "path_to_file_uri uppercases an already-lowercase drive letter" {
+  uname() { echo "MSYS_NT-10.0"; }
+  run path_to_file_uri "/d/repo/file.md"
+  [ "$output" = "file:///D:/repo/file.md" ]
+}
+
+@test "path_to_file_uri preserves an already-uppercase drive letter" {
+  uname() { echo "MINGW64_NT-10.0"; }
+  run path_to_file_uri "/C/repo/file.md"
+  [ "$output" = "file:///C:/repo/file.md" ]
+}
+
+@test "path_to_file_uri leaves plain paths untouched on Linux" {
+  uname() { echo "Linux"; }
+  run path_to_file_uri "/home/dev/.understudy-global/cursor-user-rules.md"
+  [ "$output" = "file:///home/dev/.understudy-global/cursor-user-rules.md" ]
+}
+
+@test "path_to_file_uri leaves plain paths untouched on macOS" {
+  uname() { echo "Darwin"; }
+  run path_to_file_uri "/Users/dev/.understudy-global/cursor-user-rules.md"
+  [ "$output" = "file:///Users/dev/.understudy-global/cursor-user-rules.md" ]
+}
+
+@test "path_to_file_uri falls back to a plain file:// prefix on Windows for a non-mount path" {
+  uname() { echo "MINGW64_NT-10.0"; }
+  run path_to_file_uri "relative/or/unrecognized/path.md"
+  [ "$output" = "file://relative/or/unrecognized/path.md" ]
 }

--- a/wizard.sh
+++ b/wizard.sh
@@ -1339,6 +1339,24 @@ normalize_path() {
     echo "$path"
 }
 
+# ─── Path -> clickable file:// URI ───────────────────────────
+# Converts an absolute path into a file:// URI that most modern terminals
+# (Windows Terminal, iTerm2, VS Code's integrated terminal, GNOME Terminal)
+# auto-detect and render as a clickable link. Git-bash mount-style paths
+# (/c/Users/...) are converted back to Windows drive notation
+# (file:///C:/Users/...), since that's the form file:// URIs expect on
+# Windows; Linux/macOS paths only need the scheme prepended.
+path_to_file_uri() {
+    local path="$1"
+    if [[ "$(os_family)" == "windows" ]] && [[ "$path" =~ ^/([a-zA-Z])/(.*)$ ]]; then
+        local drive="${BASH_REMATCH[1]}"
+        local rest="${BASH_REMATCH[2]}"
+        echo "file:///$(tr '[:lower:]' '[:upper:]' <<< "$drive"):/${rest}"
+    else
+        echo "file://${path}"
+    fi
+}
+
 # ─── Global mode: cross-platform path resolution ────────────
 # Helpers used only by `understudy --global` to resolve machine-wide targets.
 # Kept separate from per-project deploy so the existing project flow is
@@ -1886,6 +1904,7 @@ deploy_cursor_global() {
     info "One-time manual step:"
     info "  1. Open Cursor → Settings → Rules → User Rules"
     info "  2. Paste the contents of: ${dst}"
+    info "     $(path_to_file_uri "$dst")"
     info "Re-run 'understudy --global' anytime to refresh this file after a config change."
 
     # Canonical per-role Cursor agent files. Cursor's Agent panel only reads


### PR DESCRIPTION
## Description

`understudy --global`'s one-time Cursor setup reminder printed the path to
the generated paste-block file as plain text. This adds a clickable
`file://` link right below it (with Windows drive letters uppercased to
match OS convention), so users can jump straight from the terminal to the
file instead of copy-pasting the path manually.

While verifying this change, I found `tests/fixtures/fake-dotnet-project/`
was dead weight — no test actually references it (`detect_existing_project.bats`
builds its own throwaway `.csproj` files per test instead) — and it was
causing VS Code's C# Dev Kit extension to auto-generate a stray
`understudy.sln` next to it. Removed it in this same PR since it's a small,
related cleanup.

Closes #

---

## Type of change

- [ ] 🐛 `fix` — bug fix
- [x] ✨ `feat` — new functionality
- [ ] 📝 `docs` — documentation only
- [ ] ♻️ `refactor` — refactoring without behavior change
- [ ] 🧪 `test` — add or fix tests
- [ ] ⚙️ `ci` — CI/CD changes
- [x] 🔧 `chore` — maintenance
- [ ] 💥 Breaking change (breaks compatibility with previous versions)

---

## What changes?

- Add `path_to_file_uri()` to `wizard.sh` — converts an absolute path to a
  `file://` URI, uppercasing the drive letter on Windows git-bash mount
  paths (`/c/...` → `file:///C:/...`), passthrough on Linux/macOS.
- `deploy_cursor_global()`'s manual-step message now prints that link under
  the existing "Paste the contents of: ..." line.
- Add 6 unit tests to `tests/unit/global_paths.bats` covering Windows
  (upper/lowercase drive letters), Linux, macOS, and the no-match fallback.
- Remove the unused `tests/fixtures/fake-dotnet-project/` fixture and its
  `CONTRIBUTING.md` reference.

---

## How to test

```bash
bash -n wizard.sh
bats tests/unit/global_paths.bats

# Manual smoke test (isolate HOME/APPDATA so this never touches your real profile):
HOME=/tmp/fake-home APPDATA=/tmp/fake-home/AppData/Roaming \
  UNDERSTUDY_SKIP_JQ_INSTALL=1 \
  bash wizard.sh --global --yes --platforms cursor
# → confirm the printed instructions include a "file:///..." link
```

---

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] `CHANGELOG.md` updated in the `[Unreleased]` section
- [x] `bash -n wizard.sh` passes without errors
- [x] ShellCheck passes locally (or new warnings are justified) — not installed locally, no new patterns that would trip existing suppressions; CI will confirm
- [x] Affected documentation is updated
- [ ] If it's a new role: follows the structure of `roles/data-engineer.instructions.md` — N/A
