### PR TITLE
fix(wizard): use jq's actual install path when PATH isn't refreshed yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+
+- `understudy --global`'s automatic `jq` install (used to patch VS Code's
+  `chat.instructionsFilesLocations`/`chat.promptFilesLocations` settings) no
+  longer falls back to manual instructions when `winget`/`scoop`/`choco`
+  install `jq` successfully but the already-open terminal's `PATH` hasn't
+  picked up the change yet. It now looks the binary up at each package
+  manager's known install location and uses it by absolute path for the rest
+  of that run, so the whole flow — install, patch, uninstall — completes
+  automatically as intended.
+
 ## [1.2.0] - 2026-07-14
 
 ### Added

--- a/tests/unit/ensure_jq.bats
+++ b/tests/unit/ensure_jq.bats
@@ -240,3 +240,106 @@ teardown() { teardown_tmp; }
   [ "$JQ_INSTALLED_BY_UNDERSTUDY" = "false" ]
   grep -q "uninstall jq" "${TEST_TMP}/brew-call.log"
 }
+
+@test "cleanup_jq resets JQ_BIN back to the bare 'jq' command" {
+  JQ_INSTALLED_BY_UNDERSTUDY=true
+  JQ_PM_USED="winget"
+  JQ_BIN="${TEST_TMP}/fake/jq.exe"
+  winget() { return 0; }
+
+  cleanup_jq
+
+  [ "$JQ_BIN" = "jq" ]
+}
+
+# ── _jq_fallback_path / PATH-not-refreshed-yet recovery ───────────────────────
+# Regression coverage for the real-world case this was built for: winget (or
+# scoop/choco) installs jq successfully, but the directory it just added to
+# the user's PATH is only visible to *new* terminals — this shell's own PATH
+# was captured at startup. ensure_jq must still be able to use the binary by
+# its known, package-manager-specific absolute path in the same run.
+
+@test "ensure_jq falls back to the winget Links path when jq installs but isn't on this shell's PATH yet" {
+  uname() { echo "MINGW64_NT-10.0"; }
+  LOCALAPPDATA="${TEST_TMP}/AppData/Local"
+  mkdir -p "${LOCALAPPDATA}/Microsoft/WinGet/Links"
+  local jq_stub="${LOCALAPPDATA}/Microsoft/WinGet/Links/jq.exe"
+  cat > "$jq_stub" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x "$jq_stub"
+
+  command() {
+    if [[ "$1" == "-v" ]]; then
+      case "$2" in
+        jq)     return 1 ;;
+        scoop)  return 1 ;;
+        winget) return 0 ;;
+      esac
+    fi
+    builtin command "$@"
+  }
+  winget() { return 0; }
+  AUTO_CONFIRM=true
+
+  ensure_jq
+
+  [ "$JQ_INSTALLED_BY_UNDERSTUDY" = "true" ]
+  [ "$JQ_PM_USED" = "winget" ]
+  [ "$JQ_BIN" = "$jq_stub" ]
+}
+
+@test "ensure_jq falls back to the scoop shims path when jq installs but isn't on this shell's PATH yet" {
+  uname() { echo "MINGW64_NT-10.0"; }
+  HOME="${TEST_TMP}/fake-home"
+  mkdir -p "${HOME}/scoop/shims"
+  local jq_stub="${HOME}/scoop/shims/jq.exe"
+  cat > "$jq_stub" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x "$jq_stub"
+
+  command() {
+    if [[ "$1" == "-v" ]]; then
+      case "$2" in
+        jq)    return 1 ;;
+        scoop) return 0 ;;
+      esac
+    fi
+    builtin command "$@"
+  }
+  scoop() { return 0; }
+  AUTO_CONFIRM=true
+
+  ensure_jq
+
+  [ "$JQ_INSTALLED_BY_UNDERSTUDY" = "true" ]
+  [ "$JQ_BIN" = "$jq_stub" ]
+}
+
+@test "ensure_jq gives up and cleans up when no fallback path exists either" {
+  uname() { echo "MINGW64_NT-10.0"; }
+  LOCALAPPDATA="${TEST_TMP}/AppData/Local"
+  # Deliberately do NOT create the WinGet Links directory/binary.
+  command() {
+    if [[ "$1" == "-v" ]]; then
+      case "$2" in
+        jq)     return 1 ;;
+        scoop)  return 1 ;;
+        winget) return 0 ;;
+      esac
+    fi
+    builtin command "$@"
+  }
+  winget() { return 0; }
+  AUTO_CONFIRM=true
+
+  run_result=0
+  ensure_jq || run_result=$?
+
+  [ "$run_result" -ne 0 ]
+  [ "$JQ_INSTALLED_BY_UNDERSTUDY" = "false" ]
+  [ "$JQ_BIN" = "jq" ]
+}

--- a/wizard.sh
+++ b/wizard.sh
@@ -1844,6 +1844,8 @@ patch_vscode_settings() {
     [[ -f "$settings" ]] || echo '{}' > "$settings"
     cp "$settings" "${settings}.bak-understudy"
 
+    # shellcheck disable=SC2016 # single quotes are intentional: $i/$p are jq's
+    # own --arg-bound variables, not shell variables — must not expand here.
     if "$JQ_BIN" --arg i "$inst_dir" --arg p "$prompt_dir" \
         '.["chat.instructionsFilesLocations"] = ((.["chat.instructionsFilesLocations"] // {}) + {($i): true}) |
          .["chat.promptFilesLocations"]       = ((.["chat.promptFilesLocations"] // {}) + {($p): true})' \

--- a/wizard.sh
+++ b/wizard.sh
@@ -1450,9 +1450,36 @@ deploy_file_global() {
 # attempted blindly under sudo in a non-interactive run.
 JQ_INSTALLED_BY_UNDERSTUDY=false
 JQ_PM_USED=""
+JQ_BIN="jq"
 
 _jq_pm_available() {
     command -v "$1" &>/dev/null
+}
+
+# A package manager can report success installing jq into a directory it
+# just added to the *persistent* (registry-level) PATH — but this process's
+# own PATH was captured at shell startup and won't see it until a new
+# terminal is opened. Rather than force the user to restart their shell
+# mid-run, look the binary up directly at each package manager's known
+# install location so this run can still use it by absolute path.
+_jq_fallback_path() {
+    local candidate=""
+    case "$JQ_PM_USED" in
+        winget)
+            [[ -n "${LOCALAPPDATA:-}" ]] || return 1
+            candidate="$(normalize_path "$LOCALAPPDATA")/Microsoft/WinGet/Links/jq.exe"
+            ;;
+        scoop)
+            candidate="${HOME}/scoop/shims/jq.exe"
+            ;;
+        choco)
+            candidate="$(normalize_path "${ProgramData:-C:\\ProgramData}")/chocolatey/bin/jq.exe"
+            ;;
+        brew)
+            _jq_pm_available brew && candidate="$(brew --prefix jq 2>/dev/null)/bin/jq"
+            ;;
+    esac
+    [[ -n "$candidate" && -f "$candidate" ]] && printf '%s\n' "$candidate"
 }
 
 ensure_jq() {
@@ -1513,18 +1540,27 @@ ensure_jq() {
     esac
 
     # A package manager can report success (exit 0) without jq actually being
-    # invokable yet (e.g. winget installing to a path not yet on this shell's
-    # PATH). Trust the invocation, not the exit code, before proceeding.
-    if $JQ_INSTALLED_BY_UNDERSTUDY && command -v jq &>/dev/null; then
-        success "jq installed temporarily via ${JQ_PM_USED} (will be removed at the end of this run)"
-        trap cleanup_jq EXIT
-        return 0
-    fi
-
+    # on this shell's PATH yet (e.g. winget/scoop/choco updating the
+    # persistent, registry-level PATH that only a *new* terminal will see).
+    # Try the bare command first, then fall back to each package manager's
+    # known install location so this same run can still use it.
     if $JQ_INSTALLED_BY_UNDERSTUDY; then
-        # Installed but not yet usable in this shell — still attempt cleanup
-        # so we don't claim to have left it behind on the machine, but don't
-        # report success for the patch step.
+        if command -v jq &>/dev/null; then
+            JQ_BIN="jq"
+        else
+            JQ_BIN="$(_jq_fallback_path)"
+        fi
+
+        if [[ -n "$JQ_BIN" ]] && command -v "$JQ_BIN" &>/dev/null; then
+            success "jq installed temporarily via ${JQ_PM_USED} (will be removed at the end of this run)"
+            trap cleanup_jq EXIT
+            return 0
+        fi
+
+        # Installed but not usable by any means we know of — still attempt
+        # cleanup so we don't claim to have left it behind on the machine,
+        # but don't report success for the patch step.
+        JQ_BIN="jq"
         cleanup_jq
     fi
 
@@ -1545,6 +1581,7 @@ cleanup_jq() {
         apk)     sudo apk del jq &>/dev/null ;;
     esac
     JQ_INSTALLED_BY_UNDERSTUDY=false
+    JQ_BIN="jq"
     info "jq removed (temporary dependency cleaned up)"
 }
 
@@ -1807,7 +1844,7 @@ patch_vscode_settings() {
     [[ -f "$settings" ]] || echo '{}' > "$settings"
     cp "$settings" "${settings}.bak-understudy"
 
-    if jq --arg i "$inst_dir" --arg p "$prompt_dir" \
+    if "$JQ_BIN" --arg i "$inst_dir" --arg p "$prompt_dir" \
         '.["chat.instructionsFilesLocations"] = ((.["chat.instructionsFilesLocations"] // {}) + {($i): true}) |
          .["chat.promptFilesLocations"]       = ((.["chat.promptFilesLocations"] // {}) + {($p): true})' \
         "$settings" > "${settings}.tmp-understudy"; then


### PR DESCRIPTION
## Description

`understudy --global`'s Copilot deploy is supposed to install `jq`
temporarily, use it to patch VS Code's `settings.json`, then remove it —
fully automatic, no manual step. In practice, on Windows with `winget`
available, it was consistently falling back to manual instructions even
though `winget install` succeeded.

Root cause: `ensure_jq()` verified the install with `command -v jq`, which
depends on this shell's own `PATH` — captured at terminal startup.
`winget`/`scoop`/`choco` install `jq` into a directory they add to the
*persistent*, registry-level `PATH`, which an already-open terminal never
sees until it's restarted. `ensure_jq()` correctly detected it couldn't
verify the binary and safely uninstalled it again rather than risk leaving
an unverified dependency behind — but that meant the whole point of the
feature (fully automatic patching) never actually happened on a machine
where a package manager is present.

Closes #

---

## Type of change

- [x] 🐛 `fix` — bug fix
- [ ] ✨ `feat` — new functionality
- [ ] 📝 `docs` — documentation only
- [ ] ♻️ `refactor` — refactoring without behavior change
- [ ] 🧪 `test` — add or fix tests
- [ ] ⚙️ `ci` — CI/CD changes
- [ ] 🔧 `chore` — maintenance
- [ ] 💥 Breaking change (breaks compatibility with previous versions)

---

## What changes?

- Add `_jq_fallback_path()` to `wizard.sh`: after a package manager reports
  a successful install, if `jq` still isn't on this shell's `PATH`, look it
  up at that package manager's known install location (winget's
  `%LOCALAPPDATA%\Microsoft\WinGet\Links`, scoop's `shims`, choco's `bin`,
  brew's `--prefix`).
- `ensure_jq()` now sets `JQ_BIN` to whichever form actually resolves (bare
  `jq` or the absolute fallback path) and verifies it with `command -v`
  before declaring success, instead of giving up immediately.
- `patch_vscode_settings()` now invokes `"$JQ_BIN"` instead of assuming
  bare `jq` is on `PATH`.
- `cleanup_jq()` resets `JQ_BIN` back to `"jq"` after uninstalling.
- 4 new unit tests in `tests/unit/ensure_jq.bats` covering the winget/scoop
  fallback-path success cases and the "no fallback found either" give-up
  case.
- `CHANGELOG.md` `[Unreleased]` entry under `### Fixed`.

---

## How to test

```bash
bash -n wizard.sh
bats tests/unit/ensure_jq.bats tests/unit/patch_vscode_settings.bats

# Real end-to-end verification (Windows, with winget installed and jq NOT
# already installed) — isolates HOME/APPDATA so it never touches your real
# Claude/VS Code profiles, but lets the real winget install/uninstall cycle
# run so this isn't just mocked:
FAKE_HOME=/tmp/fake-home-jq
mkdir -p "$FAKE_HOME/AppData/Roaming/Code/User"
HOME="$FAKE_HOME" APPDATA="$FAKE_HOME/AppData/Roaming" \
  bash wizard.sh --global --yes --platforms copilot
# → expect: "jq installed temporarily via winget" / "VS Code settings.json
#   updated" / "jq removed (temporary dependency cleaned up)" — no manual
#   fallback warning.
```

---

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] `CHANGELOG.md` updated in the `[Unreleased]` section
- [x] `bash -n wizard.sh` passes without errors
- [x] ShellCheck passes locally (or new warnings are justified) — not installed locally; CI will confirm
- [x] Affected documentation is updated — N/A, behavior matches docs/12-global-mode.md as already written
- [ ] If it's a new role: follows the structure of `roles/data-engineer.instructions.md` — N/A
