### PR TITLE
chore: release v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-07-14
+
 ### Fixed
 
 - `understudy --global`'s automatic `jq` install (used to patch VS Code's


### PR DESCRIPTION
## Description

Renames `[Unreleased]` to `[1.2.1] - 2026-07-14` in `CHANGELOG.md` per the
release process in `CONTRIBUTING.md` §5, ahead of tagging `v1.2.1` (PATCH
bump — this release is a single `fix`).

Closes #

---

## Type of change

- [ ] 🐛 `fix` — bug fix
- [ ] ✨ `feat` — new functionality
- [ ] 📝 `docs` — documentation only
- [ ] ♻️ `refactor` — refactoring without behavior change
- [ ] 🧪 `test` — add or fix tests
- [ ] ⚙️ `ci` — CI/CD changes
- [x] 🔧 `chore` — maintenance
- [ ] 💥 Breaking change (breaks compatibility with previous versions)

---

## What changes?

- `CHANGELOG.md`: `[Unreleased]` → `[1.2.1] - 2026-07-14`, new empty
  `[Unreleased]` added above.

---

## How to test

```bash
# No behavior change — CHANGELOG-only edit.
head -20 CHANGELOG.md
```

---

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] `CHANGELOG.md` updated in the `[Unreleased]` section — N/A, this PR *is* the release rename
- [x] `bash -n wizard.sh` passes without errors — unaffected
- [x] ShellCheck passes locally (or new warnings are justified) — unaffected
- [x] Affected documentation is updated
- [ ] If it's a new role: follows the structure of `roles/data-engineer.instructions.md` — N/A
