### PR TITLE
docs: fix stale references to global mode, test count, and versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -359,7 +359,7 @@ so minor formatting differences do not break the gate.
 ## 8. Tests
 
 The test suite uses **[bats-core](https://github.com/bats-core/bats-core)** — the standard testing framework for bash.
-All 122 tests must pass before a PR is merged. CI runs them automatically on Ubuntu and macOS.
+All tests must pass before a PR is merged. CI runs them automatically on Ubuntu and macOS.
 
 ### Install bats
 

--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ published as a static site without restructuring.
 | [Configuration Reference](docs/09-configuration.md) | Full `understudy.yaml` reference |
 | [Caveman Mode](docs/10-caveman-mode.md) | Token-efficient role, compress script, hooks, statusline, evals |
 | [Troubleshooting and FAQ](docs/11-troubleshooting.md) | Common issues, model choice, reporting bugs |
+| [Global Mode — machine-wide install](docs/12-global-mode.md) | `--global`, `--docs-only`, `--all-roles`, Cursor's hard-link workaround, ephemeral `jq` dependency |
 
 ## Wizard Commands
 
@@ -358,6 +359,13 @@ published as a static site without restructuring.
 | `understudy --here --yes` | Same as `--here` but skip the confirmation prompt (fully unattended) |
 | `understudy --add-member` | Add a team member (data engineer, QA, etc.) |
 | `understudy --create-role` | Create a custom role from scratch |
+| `understudy --all-roles` | Deploy the entire role catalog, not just the defaults |
+| `understudy --uninstall` | Remove Understudy files from the current project |
+| `understudy --global` | Deploy a shared team machine-wide instead of per-project — see [Global Mode](docs/12-global-mode.md) |
+| `understudy --global --all-roles` | Same as `--global`, deploying the entire role catalog |
+| `understudy --global --add-member` | Add an optional role to the global team |
+| `understudy --global --uninstall` | Remove everything a `--global` deploy wrote |
+| `understudy --docs-only` | Create persistent per-repo memory (spec/ADRs/session log) without deploying agent files — pairs with `--global` |
 | `understudy --help` | Show help |
 
 > If you installed manually via `git clone`, replace `understudy` with `./wizard.sh`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,10 +4,10 @@
 
 | Version | Active Support |
 |---|---|
-| `0.1.x` | ✅ Yes |
+| `1.2.x` | ✅ Yes |
+| `< 1.2.0` | ❌ No |
 
-While the project is at `0.x.y`, only the most recent version receives security patches.
-From `1.0.0` onwards we will maintain a more detailed table of supported versions.
+Only the most recent minor release receives security patches.
 
 ## Reporting a Vulnerability
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
   - Configuration: 09-configuration.md
   - Caveman Mode: 10-caveman-mode.md
   - Troubleshooting: 11-troubleshooting.md
+  - Global Mode: 12-global-mode.md
   - Platforms:
       - GitHub Copilot CLI: platforms/copilot-cli.md
       - VS Code Copilot: platforms/vscode-copilot.md


### PR DESCRIPTION
## Description

Audited the repo's documentation (README, published GitHub Pages docs,
CONTRIBUTING, SECURITY) for staleness against the current codebase (v1.2.1).
Found four gaps, all fixed here. No CHANGELOG entry — docs-only, no
user-facing behavior change, and this doesn't warrant a version bump (the
docs site publishes on push to `main` via `.github/workflows/docs.yml`,
independent of release tags).

Closes #

---

## Type of change

- [ ] 🐛 `fix` — bug fix
- [ ] ✨ `feat` — new functionality
- [x] 📝 `docs` — documentation only
- [ ] ♻️ `refactor` — refactoring without behavior change
- [ ] 🧪 `test` — add or fix tests
- [ ] ⚙️ `ci` — CI/CD changes
- [ ] 🔧 `chore` — maintenance
- [ ] 💥 Breaking change (breaks compatibility with previous versions)

---

## What changes?

- `mkdocs.yml`: add the missing nav entry for `docs/12-global-mode.md` —
  the entire global-mode documentation page was unreachable from the
  published GitHub Pages site's sidebar navigation (it existed on disk and
  was cross-linked from other doc pages, but never added to `nav:`).
- `README.md`: list `--global`, `--docs-only`, `--all-roles`,
  `--uninstall` in the "Wizard Commands" table, and link
  `docs/12-global-mode.md` from the "Documentation" table — neither
  mentioned the feature at all despite three releases (v1.1.0–v1.2.1)
  built around it.
- `CONTRIBUTING.md`: drop the hardcoded "All 122 tests must pass" count
  (actual count is 314 and growing) so it can't go stale again.
- `SECURITY.md`: update the "Supported Versions" table — it still said
  `0.1.x` and "While the project is at `0.x.y`..." despite the project
  being at v1.2.1.

---

## How to test

```bash
# Docs-only — no script behavior to test. Spot-check locally with mkdocs
# if installed:
pip install -r docs/requirements.txt
mkdocs serve
# → confirm "Global Mode" now appears in the left nav.
```

---

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] `CHANGELOG.md` updated in the `[Unreleased]` section — N/A, docs-only, no CHANGELOG entry per project convention (user-facing behavior unchanged)
- [x] `bash -n wizard.sh` passes without errors — unaffected, no script changes
- [x] ShellCheck passes locally (or new warnings are justified) — unaffected
- [x] Affected documentation is updated
- [ ] If it's a new role: follows the structure of `roles/data-engineer.instructions.md` — N/A
